### PR TITLE
Rework from a simple example with tests, to a grpc client and service.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,2 @@
+build --enable_workspace
+info --enable_workspace

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,11 @@
-module(name = "brackets")
+module(name = "polyglot")
+
+#
+# Note: A lot of kotlin and proto/grpc stuff in here requires special handling, because grpc-kotlin does not yet
+# support BZLMOD for dependency management. It therefore has hard-coded names, like io_bazel_rules_kotlin, and
+# com_google_guava_guava, requiring these to be loaded with particular names. As soon as grpc-kotlin supports bzlmod,
+# this configuration becomes quite a bit simpler.
+#
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_go", version = "0.53.0")
@@ -10,6 +17,14 @@ bazel_dep(name = "rules_rust", version = "0.57.1")
 bazel_dep(name = "rules_python", version = "1.1.0")
 bazel_dep(name = "protobuf", version = "29.3")
 bazel_dep(name = "rules_rust_prost", version = "0.57.1")
+bazel_dep(name = "grpc", version = "1.71.0")
+bazel_dep(name = "protoc-gen-validate", version = "1.2.1.bcr.1")  # Account for a bug in 1.2.1
+
+# used by GRPC-Kotlin
+bazel_dep(name = "grpc-java", version = "1.71.0")
+bazel_dep(name = "rules_proto_grpc_java", version = "5.0.1")
+
+# grpc-kotlin does not support bzlmod, so it's loaded in WORKSPACE
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//golang:go.mod")
@@ -21,18 +36,51 @@ use_repo(
 )
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+maven.artifact(
+    testonly = True,
+    artifact = "truth",
+    group = "com.google.truth",
+    version = "1.4.4",
+)
+maven.artifact(
+    testonly = True,
+    artifact = "junit",
+    group = "junit",
+    version = "4.13.2",
+)
 maven.install(
     artifacts = [
-        "junit:junit:4.12",
-        "com.google.truth:truth:1.4.4",
+        "io.github.oshai:kotlin-logging-jvm:5.1.0",
+        "com.github.ajalt.clikt:clikt-jvm:5.0.1",
         "com.google.protobuf:protobuf-java:4.29.3",
         "com.google.protobuf:protobuf-kotlin:4.29.3",
+        "io.grpc:grpc-kotlin-stub:1.4.1",
+        "io.grpc:grpc-netty-shaded:1.71.0",
+        "io.grpc:grpc-protobuf:1.71.0",
+        "io.grpc:grpc-stub:1.71.0",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1",
+        "io.grpc:grpc-kotlin-stub:1.4.1",
+        "io.grpc:grpc-netty-shaded:1.71.0",
+        "com.linecorp.armeria:armeria-grpc:1.26.4",
+        "com.linecorp.armeria:armeria:1.26.4",
+        "org.slf4j:slf4j-api:2.0.11",
+        "org.slf4j:slf4j-jdk14:2.0.11",
+    ] + [
+        # grpc-kotlin deps
+        "com.google.guava:guava:33.3.1-android",
+        "com.squareup:kotlinpoet:1.14.2",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.1",
+        "org.jetbrains.kotlinx:kotlinx-coroutines-debug:1.10.1",
     ],
+    fetch_sources = True,
+    generate_compat_repositories = True,
     repositories = [
+        "m2local",
+        "https://maven.google.com",
         "https://repo1.maven.org/maven2",
     ],
 )
-use_repo(maven, "maven")
+use_repo(maven, "com_google_guava_guava", "maven")  # Guava called out to support kotlin-grpc which doesn't use bzlmod
 
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,13 @@
+# grpc-kotlin does not support bzlmod, so load it the old fashioned way. TODO: Fix name and bzlmod usage when supported.
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "com_github_grpc_grpc_kotlin",
+    repo_mapping = {
+        "@io_bazel_rules_kotlin": "@rules_kotlin",
+        "@io_grpc_grpc_java": "@grpc-java",
+    },
+    sha256 = "a218306e681318cbbc3b0e72ec9fe1241b2166b735427a51a3c8921c3250216f",
+    strip_prefix = "grpc-kotlin-1.4.2",
+    url = "https://github.com/grpc/grpc-kotlin/archive/refs/tags/v1.4.2.zip",
+)

--- a/java/src/main/java/bracketsjava/BUILD.bazel
+++ b/java/src/main/java/bracketsjava/BUILD.bazel
@@ -1,17 +1,17 @@
-load("@rules_java//java:java_library.bzl", "java_library")
-load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
-
-java_library(
-    name = "bracketsjava",
-    srcs = glob(["*.java"]),
-    visibility = ["//visibility:public"],
-    deps = [":example_proto_java"],
-)
-
-java_proto_library(
-    name = "example_proto_java",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//protobuf",
-    ],
-)
+#load("@rules_java//java:java_library.bzl", "java_library")
+#load("@protobuf//bazel:java_proto_library.bzl", "java_proto_library")
+#
+#java_library(
+#    name = "bracketsjava",
+#    srcs = glob(["*.java"]),
+#    visibility = ["//visibility:public"],
+#    deps = [":example_proto_java"],
+#)
+#
+#java_proto_library(
+#    name = "example_proto_java",
+#    visibility = ["//visibility:public"],
+#    deps = [
+#        "//protobuf",
+#    ],
+#)

--- a/java/src/test/java/bracketsjava/BUILD.bazel
+++ b/java/src/test/java/bracketsjava/BUILD.bazel
@@ -1,12 +1,17 @@
-load("@rules_java//java:java_test.bzl", "java_test")
-
-java_test(
-    name = "BracketsTest",
-    srcs = glob(["BracketsTest.java"]),
-    deps = [
-        "//java/src/main/java/bracketsjava",
-        "//java/src/main/java/bracketsjava:example_proto_java",
-        "@maven//:com_google_truth_truth",
-        "@maven//:junit_junit",
-    ],
-)
+#load("@rules_java//java:java_test.bzl", "java_test")
+#
+#java_test(
+#    name = "BracketsTest",
+#    srcs = glob(["BracketsTest.java"]),
+#    deps = [
+#        "//java/src/main/java/bracketsjava",
+#        "//java/src/main/java/bracketsjava:example_proto_java",
+#        "@maven//:com_google_truth_truth",
+#        "@maven//:junit_junit",
+#    ],
+#)
+#
+#alias(
+#    name = "protobuf",
+#    actual = "",
+#)

--- a/kotlin/BUILD.bazel
+++ b/kotlin/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@rules_java//java:java_binary.bzl", "java_binary")
+load("@com_github_grpc_grpc_kotlin//:kt_jvm_grpc.bzl", "kt_jvm_grpc_library", "kt_jvm_proto_library")
+
+kt_jvm_proto_library(
+    name = "balance_proto_gen",
+    visibility = ["//visibility:public"],
+    deps = ["//protobuf:balance_rpc"],
+)
+
+kt_jvm_grpc_library(
+    name = "balance_grpc_gen",
+    srcs = ["//protobuf:balance_rpc"],
+    visibility = ["//visibility:public"],
+    deps = [":balance_proto_gen"],
+)
+
+java_binary(
+    name = "brackets_client",
+    main_class = "com.geekinasuit.polyglot.brackets.client.ClientKt",
+    visibility = ["//visibility:public"],
+    runtime_deps = [
+        "//kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/client:client_lib",
+    ],
+)
+
+java_binary(
+    name = "brackets_service",
+    main_class = "com.geekinasuit.polyglot.brackets.service.ServiceKt",
+    visibility = ["//visibility:public"],
+    runtime_deps = [
+        "//kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service:service_lib",
+    ],
+)

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/client/BUILD.bazel
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/client/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+load("@com_github_grpc_grpc_kotlin//:kt_jvm_grpc.bzl", "kt_jvm_grpc_library", "kt_jvm_proto_library")
+
+kt_jvm_library(
+    name = "client_lib",
+    srcs = glob(["*.kt"]),
+    visibility = ["//visibility:public"],
+    runtime_deps = ["@maven//:org_slf4j_slf4j_jdk14"],
+    deps = [
+        "//kotlin:balance_grpc_gen",
+        "@maven//:com_github_ajalt_clikt_clikt_jvm",
+        "@maven//:io_github_oshai_kotlin_logging_jvm",
+        "@maven//:io_grpc_grpc_netty_shaded",
+        "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
+    ],
+)

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/client/client.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/client/client.kt
@@ -1,0 +1,60 @@
+package com.geekinasuit.polyglot.brackets.client
+
+import com.geekinasuit.polyglot.brackets.service.protos.BalanceBracketsGrpcKt
+import com.geekinasuit.polyglot.brackets.service.protos.BalanceRequest
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.ProgramResult
+import com.github.ajalt.clikt.core.main
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.help
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.inputStream
+import com.github.ajalt.clikt.parameters.types.int
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.grpc.ManagedChannelBuilder
+import java.io.BufferedReader
+import kotlinx.coroutines.runBlocking
+
+private const val DEFAULT_HOST = "localhost"
+private const val DEFAULT_PORT = 8888
+private val log = KotlinLogging.logger {}
+
+class BracketsClient : CliktCommand(name = "brackets_client") {
+  val host by option().default(DEFAULT_HOST).help("Service IP port number")
+  val port by option().int().default(DEFAULT_PORT).help("Service IP port number")
+  val text by argument().inputStream()
+
+  override fun run(): Unit = runBlocking {
+    println("brackets client running...")
+    val buffer = text.bufferedReader().use(BufferedReader::readText)
+    text.close()
+
+    println("About to check:\n========")
+    println(buffer)
+    println("========")
+    val channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build()
+    val stub = BalanceBracketsGrpcKt.BalanceBracketsCoroutineStub(channel)
+    val request = BalanceRequest.newBuilder().setStatement(buffer.toString()).build()
+    val response =
+      try {
+        stub.balance(request)
+      } catch (e: Exception) {
+        System.err.println(
+          "Error connecting to bracket balance service: ${e.cause?.message ?: e.message}"
+        )
+        throw ProgramResult(1)
+      }
+    log.info { response }
+    when {
+      !response.succeeded -> {
+        System.err.println("Error balancing brackets: ${response.error}")
+        throw ProgramResult(2)
+      }
+      response.isBalanced -> println("Brackets are balanced.")
+      else -> println("Brackets are NOT balanced: ${response.error}")
+    }
+  }
+}
+
+fun main(vararg args: String) = BracketsClient().main(args)

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BUILD.bazel
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+load("@com_github_grpc_grpc_kotlin//:kt_jvm_grpc.bzl", "kt_jvm_grpc_library", "kt_jvm_proto_library")
+
+kt_jvm_library(
+    name = "service_lib",
+    srcs = glob(["*.kt"]),
+    visibility = ["//visibility:public"],
+    runtime_deps = ["@maven//:org_slf4j_slf4j_jdk14"],
+    deps = [
+        "//kotlin:balance_grpc_gen",
+        "//kotlin/src/main/kotlin/bracketskt",
+        "@grpc-java//stub",
+        "@maven//:com_github_ajalt_clikt_clikt_jvm",
+        "@maven//:com_linecorp_armeria_armeria",
+        "@maven//:com_linecorp_armeria_armeria_grpc",
+        "@maven//:io_github_oshai_kotlin_logging_jvm",
+        "@maven//:io_grpc_grpc_api",
+    ],
+)

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BalanceServiceEndpoint.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BalanceServiceEndpoint.kt
@@ -1,0 +1,42 @@
+package com.geekinasuit.polyglot.brackets.service
+
+import bracketskt.BracketsNotBalancedException
+import bracketskt.balancedBrackets
+import com.geekinasuit.polyglot.brackets.service.protos.BalanceBracketsGrpc
+import com.geekinasuit.polyglot.brackets.service.protos.BalanceRequest
+import com.geekinasuit.polyglot.brackets.service.protos.BalanceResponse
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.grpc.BindableService
+import io.grpc.ServerServiceDefinition
+import io.grpc.stub.StreamObserver
+
+private val log = KotlinLogging.logger {}
+
+class BalanceServiceEndpoint() : BalanceBracketsGrpc.AsyncService, BindableService {
+  override fun balance(request: BalanceRequest, responseObserver: StreamObserver<BalanceResponse>) {
+    val responseBuilder =
+      BalanceResponse.newBuilder().apply {
+        val balancedResult =
+          try {
+            log.info { "About to try balancing brackets: \"${request.statement}\"" }
+            balancedBrackets(request.statement)
+            log.info { "Balanced brackets completed without error." }
+            setIsBalanced(true)
+            setSucceeded(true)
+          } catch (e: BracketsNotBalancedException) {
+            setIsBalanced(false)
+            setSucceeded(true)
+            log.info { "Brackets were not balanced: ${e.message}" }
+            setError(e.message)
+          } catch (e: Exception) {
+            setSucceeded(false)
+            log.info { "Error balancing brackets: ${e.message}" }
+            setError(e.message)
+          }
+      }
+    responseObserver.onNext(responseBuilder.build())
+    responseObserver.onCompleted()
+  }
+
+  override fun bindService(): ServerServiceDefinition = BalanceBracketsGrpc.bindService(this)
+}

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/service.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/service.kt
@@ -1,0 +1,38 @@
+package com.geekinasuit.polyglot.brackets.service
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.main
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.help
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.int
+import com.linecorp.armeria.server.Server
+import com.linecorp.armeria.server.grpc.GrpcService
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.grpc.BindableService
+import io.grpc.ServerInterceptor
+
+private const val DEFAULT_HOST = "localhost"
+private const val DEFAULT_PORT = 8888
+private val log = KotlinLogging.logger {}
+
+class BracketsService : CliktCommand(name = "brackets_service") {
+  val host by option().default(DEFAULT_HOST).help("Service IP port number")
+  val port: Int by option().int().default(DEFAULT_PORT).help("Service IP port number")
+
+  override fun run() {
+    println("brackets service starting...")
+    val server = Server.builder().http(port).service(wrapService(BalanceServiceEndpoint())).build()
+    server.closeOnJvmShutdown().thenRun { log.info { "Server has been stopped." } }
+    server.start().join()
+  }
+}
+
+fun main(vararg args: String) = BracketsService().main(args)
+
+fun wrapService(
+  bindableService: BindableService,
+  vararg interceptors: ServerInterceptor,
+): GrpcService {
+  return GrpcService.builder().addService(bindableService).intercept(*interceptors).build()
+}

--- a/protobuf/BUILD.bazel
+++ b/protobuf/BUILD.bazel
@@ -6,3 +6,10 @@ proto_library(
     # deps = ["@com_google_protobuf//:timestamp_proto"],
     visibility = ["//visibility:public"],
 )
+
+proto_library(
+    name = "balance_rpc",
+    srcs = ["brackets_service.proto"],
+    # deps = ["@com_google_protobuf//:timestamp_proto"],
+    visibility = ["//visibility:public"],
+)

--- a/protobuf/brackets_service.proto
+++ b/protobuf/brackets_service.proto
@@ -1,0 +1,22 @@
+ syntax = "proto3";
+
+package brackets_service;
+
+option java_multiple_files = true;
+option java_package = "com.geekinasuit.polyglot.brackets.service.protos";
+option java_outer_classname = "BalanceBracketsService";
+
+
+service BalanceBrackets {
+  rpc Balance(BalanceRequest) returns (BalanceResponse);
+}
+
+message BalanceRequest {
+  string statement = 1;
+}
+
+message BalanceResponse {
+  bool succeeded = 1;
+  string error = 2;
+  bool is_balanced = 3;
+}


### PR DESCRIPTION
This PR just creates the kotlin version. 

To use grpc-kotlin it uses the bazel <= 8 legacy WORKSPACE feature, as grpc-kotlin does not support BZLMOD style dependencies. 