### PR TITLE
Add Buildkite CI pipeline

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,8 @@
 common --enable_workspace=true --java_runtime_version=21
 build --enable_workspace
 info --enable_workspace
+
+# CI config: enable sandboxing (seatbelt on macOS, namespaces on Linux) and local disk cache.
+# All Buildkite pipeline steps pass --config=ci.
+build:ci --spawn_strategy=sandboxed
+build:ci --disk_cache=/tmp/bazel-disk-cache

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,8 +36,9 @@ steps:
           always-pull: false
     command: |
       apt-get update -qq && apt-get install -y curl python3 git > /dev/null
+      ARCH=$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
       curl -fsSL -o /usr/local/bin/bazel \
-        https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-amd64
+        https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-$${ARCH}
       chmod +x /usr/local/bin/bazel
       bazel build --config=ci //...
 
@@ -63,8 +64,9 @@ steps:
             - HOME=/root
     command: |
       apt-get update -qq && apt-get install -y curl python3 git > /dev/null
+      ARCH=$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
       curl -fsSL -o /usr/local/bin/bazel \
-        https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-amd64
+        https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-$${ARCH}
       chmod +x /usr/local/bin/bazel
       bazel test --config=ci //...
 
@@ -90,8 +92,9 @@ steps:
             - HOME=/root
     command: |
       apt-get update -qq && apt-get install -y curl python3 git > /dev/null
+      ARCH=$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
       curl -fsSL -o /usr/local/bin/bazel \
-        https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-amd64
+        https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-$${ARCH}
       chmod +x /usr/local/bin/bazel
       bazel run --config=ci //golang/cmd/brackets
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -102,7 +102,7 @@ steps:
     depends_on: test-linux
     plugins:
       - docker#v5.11.0:
-          image: "golang:1.24-bookworm"
+          image: "golang:1.25-bookworm"
           volumes:
             - "/tmp/bk-go-cache:/go/pkg/mod"
           environment:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -35,7 +35,7 @@ steps:
             - HOME=/root
           always-pull: false
     command: |
-      apt-get update -qq && apt-get install -y curl python3 git > /dev/null
+      apt-get update -qq && apt-get install -y curl python3 git build-essential > /dev/null
       ARCH=$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
       curl -fsSL -o /usr/local/bin/bazel \
         https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-$${ARCH}
@@ -63,7 +63,7 @@ steps:
           environment:
             - HOME=/root
     command: |
-      apt-get update -qq && apt-get install -y curl python3 git > /dev/null
+      apt-get update -qq && apt-get install -y curl python3 git build-essential > /dev/null
       ARCH=$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
       curl -fsSL -o /usr/local/bin/bazel \
         https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-$${ARCH}
@@ -91,7 +91,7 @@ steps:
           environment:
             - HOME=/root
     command: |
-      apt-get update -qq && apt-get install -y curl python3 git > /dev/null
+      apt-get update -qq && apt-get install -y curl python3 git build-essential > /dev/null
       ARCH=$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
       curl -fsSL -o /usr/local/bin/bazel \
         https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-$${ARCH}

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -111,7 +111,7 @@ steps:
       apt-get update -qq && apt-get install -y protobuf-compiler git make > /dev/null
       go install github.com/golang/protobuf/protoc-gen-go@latest
       go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
-      export PATH="$PATH:$(go env GOPATH)/bin"
+      export PATH="$$PATH:$$(go env GOPATH)/bin"
       make go-test
       make go-run
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,136 @@
+# Buildkite CI Pipeline
+#
+# Mirrors .github/workflows/ci.yaml with two platforms:
+#   Linux  — steps run inside ubuntu:22.04 Docker containers via the Docker plugin
+#   macOS  — steps run natively on the Mac agent with Bazel seatbelt sandboxing
+#
+# Dependency graph:
+#   build-linux ──┬── test-linux ──┬── go-exec-bazel-linux
+#                 │                ├── go-exec-make-linux
+#                 │                └── kotlin-integration-linux
+#
+#   build-macos ──┴── test-macos ──┬── go-exec-bazel-macos
+#                                  └── kotlin-integration-macos
+#
+# Plugins:
+#   docker#v5.11.0  https://github.com/buildkite-plugins/docker-buildkite-plugin  (Apache-2.0)
+
+env:
+  BUILDKITE_CLEAN_CHECKOUT: "true"
+
+steps:
+
+  ##############################################################################
+  # BUILD PHASE — fail fast before running tests
+  ##############################################################################
+
+  - label: ":bazel: Build (Linux)"
+    key: build-linux
+    plugins:
+      - docker#v5.11.0:
+          image: "ubuntu:22.04"
+          volumes:
+            - "/tmp/bk-bazel-cache:/tmp/bazel-disk-cache"
+          environment:
+            - HOME=/root
+          always-pull: false
+    command: |
+      apt-get update -qq && apt-get install -y curl python3 git > /dev/null
+      curl -fsSL -o /usr/local/bin/bazel \
+        https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-amd64
+      chmod +x /usr/local/bin/bazel
+      bazel build --config=ci //...
+
+  - label: ":apple: Build (macOS)"
+    key: build-macos
+    agents:
+      os: macos
+    command: bazel build --config=ci //...
+
+  ##############################################################################
+  # TEST PHASE — parallel per platform
+  ##############################################################################
+
+  - label: ":bazel: Test (Linux)"
+    key: test-linux
+    depends_on: build-linux
+    plugins:
+      - docker#v5.11.0:
+          image: "ubuntu:22.04"
+          volumes:
+            - "/tmp/bk-bazel-cache:/tmp/bazel-disk-cache"
+          environment:
+            - HOME=/root
+    command: |
+      apt-get update -qq && apt-get install -y curl python3 git > /dev/null
+      curl -fsSL -o /usr/local/bin/bazel \
+        https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-amd64
+      chmod +x /usr/local/bin/bazel
+      bazel test --config=ci //...
+
+  - label: ":apple: Test (macOS)"
+    key: test-macos
+    depends_on: build-macos
+    agents:
+      os: macos
+    command: bazel test --config=ci //...
+
+  ##############################################################################
+  # EXECUTION TESTS — binary execution tests
+  ##############################################################################
+
+  - label: ":go: Go exec via Bazel (Linux)"
+    depends_on: test-linux
+    plugins:
+      - docker#v5.11.0:
+          image: "ubuntu:22.04"
+          volumes:
+            - "/tmp/bk-bazel-cache:/tmp/bazel-disk-cache"
+          environment:
+            - HOME=/root
+    command: |
+      apt-get update -qq && apt-get install -y curl python3 git > /dev/null
+      curl -fsSL -o /usr/local/bin/bazel \
+        https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-amd64
+      chmod +x /usr/local/bin/bazel
+      bazel run --config=ci //golang/cmd/brackets
+
+  - label: ":go: Go exec via Make (Linux)"
+    depends_on: test-linux
+    plugins:
+      - docker#v5.11.0:
+          image: "golang:1.22-bookworm"
+          volumes:
+            - "/tmp/bk-go-cache:/go/pkg/mod"
+          environment:
+            - GOPATH=/go
+    command: |
+      apt-get update -qq && apt-get install -y protobuf-compiler git make > /dev/null
+      go install github.com/golang/protobuf/protoc-gen-go@latest
+      go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+      export PATH="$PATH:$(go env GOPATH)/bin"
+      make go-test
+      make go-run
+
+  - label: ":kotlin: Kotlin integration test (Linux)"
+    depends_on: test-linux
+    plugins:
+      - docker#v5.11.0:
+          image: "ubuntu:22.04"
+          volumes:
+            - "/tmp/bk-bazel-cache:/tmp/bazel-disk-cache"
+          environment:
+            - HOME=/root
+    command: .buildkite/scripts/kotlin-integration-test.sh
+
+  - label: ":go: Go exec via Bazel (macOS)"
+    depends_on: test-macos
+    agents:
+      os: macos
+    command: bazel run --config=ci //golang/cmd/brackets
+
+  - label: ":apple: :kotlin: Kotlin integration test (macOS)"
+    depends_on: test-macos
+    agents:
+      os: macos
+    command: .buildkite/scripts/kotlin-integration-test.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -102,7 +102,7 @@ steps:
     depends_on: test-linux
     plugins:
       - docker#v5.11.0:
-          image: "golang:1.22-bookworm"
+          image: "golang:1.24-bookworm"
           volumes:
             - "/tmp/bk-go-cache:/go/pkg/mod"
           environment:

--- a/.buildkite/scripts/kotlin-integration-test.sh
+++ b/.buildkite/scripts/kotlin-integration-test.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 
 if ! command -v bazel &> /dev/null; then
   echo "--- Installing bazelisk"
-  apt-get update -qq && apt-get install -y curl python3 git > /dev/null
+  apt-get update -qq && apt-get install -y curl python3 git build-essential > /dev/null
   ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
   curl -fsSL -o /usr/local/bin/bazel \
     https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-${ARCH}

--- a/.buildkite/scripts/kotlin-integration-test.sh
+++ b/.buildkite/scripts/kotlin-integration-test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Kotlin gRPC integration test
+# Runs on both Linux (Docker container) and macOS (native agent).
+#
+# On Linux containers, bazelisk is not pre-installed — this script bootstraps it.
+# On macOS, `bazel` resolves to bazelisk already in PATH; the bootstrap is a no-op.
+
+##############################################################################
+# Bootstrap bazelisk if not present (Linux Docker containers)
+##############################################################################
+
+if ! command -v bazel &> /dev/null; then
+  echo "--- Installing bazelisk"
+  apt-get update -qq && apt-get install -y curl python3 git > /dev/null
+  curl -fsSL -o /usr/local/bin/bazel \
+    https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-amd64
+  chmod +x /usr/local/bin/bazel
+fi
+
+##############################################################################
+# Build
+##############################################################################
+
+SERVICE_PORT=19999
+
+echo "--- Building service and client"
+bazel build --config=ci //kotlin:brackets_client //kotlin:brackets_service
+
+##############################################################################
+# Start service with guaranteed cleanup
+##############################################################################
+
+echo "--- Starting service on port ${SERVICE_PORT}"
+bazel-bin/kotlin/brackets_service --port="${SERVICE_PORT}" &
+SERVICE_PID=$!
+
+cleanup() {
+  echo "--- Stopping service (pid ${SERVICE_PID})"
+  kill "${SERVICE_PID}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+##############################################################################
+# Wait for service to be ready
+##############################################################################
+
+echo "--- Waiting for service to accept connections"
+timeout=30
+while ! (echo > /dev/tcp/localhost/${SERVICE_PORT}) &>/dev/null; do
+  ((timeout--)) || {
+    echo "ERROR: Service did not start on port ${SERVICE_PORT} within 30s"
+    exit 1
+  }
+  sleep 1
+done
+echo "Service is ready on port ${SERVICE_PORT} (pid ${SERVICE_PID})"
+
+##############################################################################
+# Integration tests
+##############################################################################
+
+echo "--- Running integration tests"
+
+echo "foo ( bar ( baz ) { blah } [ what!!? ] )" > /tmp/kt-test1.txt
+echo "foo ( bar ( baz ] { blah } [ what!!? ] )" > /tmp/kt-test2.txt
+
+echo "  Test 1: balanced input"
+if bazel-bin/kotlin/brackets_client --port="${SERVICE_PORT}" /tmp/kt-test1.txt \
+    | grep -q "Brackets are balanced"; then
+  echo "  PASSED"
+else
+  echo "  FAILED — expected 'Brackets are balanced'"
+  exit 1
+fi
+
+echo "  Test 2: unbalanced input"
+if bazel-bin/kotlin/brackets_client --port="${SERVICE_PORT}" /tmp/kt-test2.txt \
+    | grep -q "Brackets are NOT balanced"; then
+  echo "  PASSED"
+else
+  echo "  FAILED — expected 'Brackets are NOT balanced'"
+  exit 1
+fi
+
+echo "--- All integration tests passed"

--- a/.buildkite/scripts/kotlin-integration-test.sh
+++ b/.buildkite/scripts/kotlin-integration-test.sh
@@ -14,8 +14,9 @@ set -euo pipefail
 if ! command -v bazel &> /dev/null; then
   echo "--- Installing bazelisk"
   apt-get update -qq && apt-get install -y curl python3 git > /dev/null
+  ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')
   curl -fsSL -o /usr/local/bin/bazel \
-    https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-amd64
+    https://github.com/bazelbuild/bazelisk/releases/download/v1.20.0/bazelisk-linux-${ARCH}
   chmod +x /usr/local/bin/bazel
 fi
 

--- a/thoughts/shared/plans/2026-03-06-buildkite-ci.md
+++ b/thoughts/shared/plans/2026-03-06-buildkite-ci.md
@@ -146,7 +146,7 @@ A future improvement (noted below) would replace this with a pre-built CI image.
 ### Success Criteria
 
 #### Automated Verification:
-- [ ] `buildkite-agent pipeline upload .buildkite/pipeline.yml` produces no YAML errors
+- [x] `buildkite-agent pipeline upload .buildkite/pipeline.yml` produces no YAML errors
 
 #### Manual Verification:
 - [ ] First full build passes end-to-end in the Buildkite dashboard
@@ -177,8 +177,8 @@ Make the script executable (`chmod +x`) as part of creation.
 ### Success Criteria
 
 #### Automated Verification:
-- [ ] `shellcheck .buildkite/scripts/kotlin-integration-test.sh` passes with no errors
-- [ ] Script is executable: `test -x .buildkite/scripts/kotlin-integration-test.sh`
+- [x] `shellcheck .buildkite/scripts/kotlin-integration-test.sh` passes with no errors
+- [x] Script is executable: `test -x .buildkite/scripts/kotlin-integration-test.sh`
 
 #### Manual Verification:
 - [ ] Script runs to completion locally on macOS against pre-built binaries

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -38,3 +38,4 @@ Ticket files are the source of truth. GitHub Issues are a thin, work-time-only l
 | Summary | Resolution |
 |---|---|
 | Machine-specific cache config in repo `.bazelrc` | Resolved directly: `--disk_cache` and `--remote_cache` lines removed from `.bazelrc`; developers configure cache in `user.bazelrc` (gitignored) or `~/.bazelrc` |
+| Buildkite CI pipeline (issue #13, PR #14) | Implemented pipeline mirroring GitHub Actions: Linux steps via Docker plugin, macOS steps on native agent (`os=macos`). Fixes during stabilization: cluster assignment, arch-aware bazelisk download, `build-essential` for `rules_cc`, Go image bumped to 1.25, `$$`-escaped Buildkite variable interpolation in Docker command blocks. |


### PR DESCRIPTION
Closes #13

## Summary

- **`.bazelrc`**: add `build:ci` config — `--spawn_strategy=sandboxed` (macOS seatbelt via `sandbox-exec`, Linux namespace sandboxing) and `--disk_cache=/tmp/bazel-disk-cache` for local disk caching
- **`.buildkite/pipeline.yml`**: 9-step pipeline mirroring all 5 GitHub Actions jobs on two platforms:
  - Linux: `ubuntu:22.04` via `docker#v5.11.0` plugin (volume-mounted Bazel cache)
  - macOS native: runs on agent tagged `os=macos`
  - Dependency graph: build → test → exec tests, independently per platform
- **`.buildkite/scripts/kotlin-integration-test.sh`**: standalone gRPC integration test script (shellcheck-clean), shared by Linux and macOS steps; uses `trap` for reliable service cleanup

## Test plan

- [x] Phase 4 (agent tag + buildkite.com pipeline creation) complete on the agent machine
- [x] First full Buildkite build passes end-to-end
- [x] Dependency graph in Buildkite UI shows correct ordering
- [x] Second build is faster (Bazel disk cache warm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)