### PR TITLE
Remove grpc_kotlin WORKSPACE workarounds (bzlmod migration)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,4 @@
-common --enable_workspace=true --java_runtime_version=21
-build --enable_workspace
-info --enable_workspace
+common --java_runtime_version=21
 
 # CI config: enable sandboxing (seatbelt on macOS, namespaces on Linux) and local disk cache.
 # All Buildkite pipeline steps pass --config=ci.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,12 +1,5 @@
 module(name = "polyglot")
 
-#
-# Note: A lot of kotlin and proto/grpc stuff in here requires special handling, because grpc-kotlin does not yet
-# support BZLMOD for dependency management. It therefore has hard-coded names, like io_bazel_rules_kotlin, and
-# com_google_guava_guava, requiring these to be loaded with particular names. As soon as grpc-kotlin supports bzlmod,
-# this configuration becomes quite a bit simpler.
-#
-
 bazel_dep(name = "bazel_skylib", version = "1.8.2")
 bazel_dep(name = "rules_go", version = "0.57.0")
 bazel_dep(name = "gazelle", version = "0.45.0")
@@ -61,12 +54,6 @@ maven.install(
         "com.linecorp.armeria:armeria:1.26.4",
         "org.slf4j:slf4j-api:2.0.11",
         "org.slf4j:slf4j-jdk14:2.0.11",
-    ] + [
-        # grpc-kotlin deps
-        "com.google.guava:guava:33.3.1-android",
-        "com.squareup:kotlinpoet:1.14.2",
-        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.1",
-        "org.jetbrains.kotlinx:kotlinx-coroutines-debug:1.10.1",
     ],
     fetch_sources = True,
     generate_compat_repositories = True,
@@ -76,7 +63,7 @@ maven.install(
         "https://repo1.maven.org/maven2",
     ],
 )
-use_repo(maven, "com_google_guava_guava", "maven", "grpc_kotlin_maven")  # Guava called out to support kotlin-grpc which doesn't use bzlmod
+use_repo(maven, "maven", "grpc_kotlin_maven")
 
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(

--- a/thoughts/shared/plans/2026-03-07-grpc-kotlin-bzlmod-migration.md
+++ b/thoughts/shared/plans/2026-03-07-grpc-kotlin-bzlmod-migration.md
@@ -1,0 +1,125 @@
+# grpc-kotlin bzlmod Migration Plan
+
+## Overview
+
+Remove the legacy WORKSPACE compatibility workarounds introduced to accommodate
+`grpc_kotlin 1.5.0` before it was published to the Bazel Central Registry. The
+BCR now carries `grpc_kotlin 1.5.0` with a proper `MODULE.bazel`, making the
+workarounds unnecessary.
+
+## Current State Analysis
+
+The project already declares `bazel_dep(name = "grpc_kotlin", version = "1.5.0")`
+and therefore already uses the BCR-patched version. Three workarounds remain from
+when `grpc_kotlin` was not BCR-native:
+
+1. **`.bazelrc` lines 1–3** — `--enable_workspace=true` (set twice, redundantly)
+2. **`MODULE.bazel` lines 4–7** — explanatory comment about the workaround
+3. **`MODULE.bazel` lines 65–70** — guava, kotlinpoet, and coroutines entries
+   added specifically for grpc-kotlin's legacy repo name requirements
+4. **`MODULE.bazel` line 79** — `com_google_guava_guava` and `grpc_kotlin_maven`
+   explicitly listed in `use_repo(maven, ...)` to expose those compat repos
+
+No project `BUILD.bazel` files reference `@com_google_guava_guava` or
+`@grpc_kotlin_maven` directly — the workarounds are confined to module config.
+
+### Why this is now safe to remove
+
+- `grpc_kotlin 1.5.0`'s BCR `MODULE.bazel` declares its own `grpc_kotlin_maven`
+  extension, meaning Bazel manages those transitive deps internally within the
+  `grpc_kotlin` module.
+- `kt_jvm_grpc.bzl` loads only from proper bzlmod module names (`@grpc-java`,
+  `@protobuf`, `@rules_kotlin`, `@rules_java`).
+- Internal grpc-kotlin BUILD files reference `@grpc_kotlin_maven//:...` (namespaced,
+  not bare `@com_google_guava_guava`), which the BCR module resolves internally.
+
+## Desired End State
+
+- `.bazelrc` contains no `--enable_workspace` flags
+- `MODULE.bazel` contains no grpc-kotlin compat entries or explanatory comment
+- `bazel build //kotlin/...` and `bazel test //kotlin/...` pass cleanly
+
+## What We're NOT Doing
+
+- Upgrading `grpc_kotlin` to a different version (staying on `1.5.0`)
+- Changing any `BUILD.bazel` files in the project
+- Modifying the Kotlin service, client, or proto codegen targets
+- Removing the custom `//util:kt_jvm_proto.bzl` macro (unrelated)
+
+## Implementation
+
+### Step 1 — Remove `.bazelrc` workspace flags
+
+**File**: `.bazelrc`
+
+Remove lines 1–3:
+```
+common --enable_workspace=true --java_runtime_version=21
+build --enable_workspace
+info --enable_workspace
+```
+
+Replace with:
+```
+common --java_runtime_version=21
+```
+
+### Step 2 — Clean up `MODULE.bazel`
+
+**File**: `MODULE.bazel`
+
+1. Delete lines 4–7 (the explanatory comment block).
+
+2. Delete lines 65–70 (the grpc-kotlin compat maven entries):
+   ```python
+       # grpc-kotlin deps
+       "com.google.guava:guava:33.3.1-android",
+       "com.squareup:kotlinpoet:1.14.2",
+       "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.1",
+       "org.jetbrains.kotlinx:kotlinx-coroutines-debug:1.10.1",
+   ```
+   > Note: `kotlinx-coroutines-core` (without `-jvm` suffix, line 57) is a real
+   > runtime dependency for the Kotlin client — keep it.
+
+3. On line 79, remove `"com_google_guava_guava"` and `"grpc_kotlin_maven"` from
+   the `use_repo` call, leaving only:
+   ```python
+   use_repo(maven, "maven")
+   ```
+
+### Step 3 — Verify
+
+```bash
+bazel build //kotlin/...
+bazel test //kotlin/...
+```
+
+Both must pass cleanly with no WORKSPACE-related warnings or errors.
+
+## Success Criteria
+
+### Automated Verification
+- [ ] `bazel build //kotlin/...` succeeds with no errors
+- [ ] `bazel test //kotlin/...` passes
+- [ ] No `--enable_workspace` warnings in build output
+- [ ] All other language targets still build: `bazel build //...`
+
+### Manual Verification
+- [ ] Start the Kotlin gRPC service and connect with the client; confirm balanced/
+      unbalanced responses work correctly
+
+## Rollback
+
+If the build fails after removing `--enable_workspace=true`, re-add it and open
+an investigation issue with the specific error. Likely failure modes:
+- A stale WORKSPACE file reference inside grpc-kotlin's own targets (investigate
+  with `bazel query` to trace the dep)
+- A `rules_jvm_external` lock file mismatch requiring `REPIN=1`
+
+## References
+
+- Ticket: `thoughts/shared/tickets/grpc-kotlin-bzlmod-migration.md`
+- Codebase overview: `thoughts/shared/research/2026-03-05-polyglot-codebase-overview.md`
+- BCR module: `https://registry.bazel.build/modules/grpc_kotlin`
+- grpc-kotlin bzlmod issue: `https://github.com/grpc/grpc-kotlin/issues/398`
+- grpc-kotlin bzlmod PR (open): `https://github.com/grpc/grpc-kotlin/pull/618`

--- a/thoughts/shared/plans/2026-03-07-grpc-kotlin-bzlmod-migration.md
+++ b/thoughts/shared/plans/2026-03-07-grpc-kotlin-bzlmod-migration.md
@@ -96,13 +96,24 @@ bazel test //kotlin/...
 
 Both must pass cleanly with no WORKSPACE-related warnings or errors.
 
+## Implementation Note
+
+During implementation, removing `use_repo(..., "grpc_kotlin_maven")` caused the build to fail
+with `No repository visible as '@grpc_kotlin_maven' from main repository`. The fix was to keep
+`"grpc_kotlin_maven"` in the `use_repo` call — this exposes the repo created by grpc_kotlin's
+internal BCR maven extension to our module via the shared `rules_jvm_external` extension. This
+pattern is confirmed by grpc-kotlin's own bzlmod example (`bzl-examples/bzlmod/MODULE.bazel`).
+
+The `com_google_guava_guava` entry and the guava/kotlinpoet maven artifacts were pure WORKSPACE-era
+overhead and are now cleanly removed.
+
 ## Success Criteria
 
 ### Automated Verification
-- [ ] `bazel build //kotlin/...` succeeds with no errors
-- [ ] `bazel test //kotlin/...` passes
-- [ ] No `--enable_workspace` warnings in build output
-- [ ] All other language targets still build: `bazel build //...`
+- [x] `bazel build //kotlin/...` succeeds with no errors
+- [x] `bazel test //kotlin/...` passes
+- [x] No `--enable_workspace` warnings in build output
+- [x] All other language targets still build: `bazel build //...`
 
 ### Manual Verification
 - [ ] Start the Kotlin gRPC service and connect with the client; confirm balanced/

--- a/thoughts/shared/tickets/grpc-kotlin-bzlmod-migration.md
+++ b/thoughts/shared/tickets/grpc-kotlin-bzlmod-migration.md
@@ -1,8 +1,10 @@
 ---
 date: 2026-03-05
-status: open
+status: planned
 priority: low
 area: kotlin, bazel, grpc
+github: https://github.com/geekinasuit/polyglot/issues/15
+plan: thoughts/shared/plans/2026-03-07-grpc-kotlin-bzlmod-migration.md
 ---
 
 # Future: Migrate grpc_kotlin to bzlmod-native version when available

--- a/thoughts/shared/tickets/grpc-kotlin-bzlmod-migration.md
+++ b/thoughts/shared/tickets/grpc-kotlin-bzlmod-migration.md
@@ -1,6 +1,6 @@
 ---
 date: 2026-03-05
-status: planned
+status: done
 priority: low
 area: kotlin, bazel, grpc
 github: https://github.com/geekinasuit/polyglot/issues/15


### PR DESCRIPTION
Closes #15

## Summary

`grpc_kotlin 1.5.0` is on the Bazel Central Registry with a proper `MODULE.bazel`, making our legacy WORKSPACE compatibility workarounds unnecessary.

## Changes

- **`.bazelrc`**: Remove `--enable_workspace=true` / `--enable_workspace` (3 lines → 1)
- **`MODULE.bazel`**: Remove the explanatory comment block
- **`MODULE.bazel`**: Remove guava, kotlinpoet, coroutines-jvm, coroutines-debug maven artifacts (WORKSPACE-era overhead; grpc_kotlin's BCR module manages these internally via its own `grpc_kotlin_maven` install)
- **`MODULE.bazel`**: Remove `com_google_guava_guava` from `use_repo`
- **`MODULE.bazel`**: Keep `"grpc_kotlin_maven"` in `use_repo` — this exposes grpc_kotlin's internal BCR maven install to our module via the shared `rules_jvm_external` extension (the correct bzlmod pattern, confirmed by grpc-kotlin's own `bzl-examples/bzlmod` example)

## Verification

- `bazel build //kotlin/...` ✓
- `bazel test //kotlin/...` ✓ (`BracketsTest` passes)
- `bazel build //...` ✓ (all languages still build)