### PR TITLE
Phase 1: Hoplite config system + ConfigCommand option binding

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -52,6 +52,8 @@ maven.install(
         "io.grpc:grpc-netty-shaded:1.71.0",
         "com.linecorp.armeria:armeria-grpc:1.26.4",
         "com.linecorp.armeria:armeria:1.26.4",
+        "com.sksamuel.hoplite:hoplite-core:2.9.0",
+        "com.sksamuel.hoplite:hoplite-yaml:2.9.0",
         "org.slf4j:slf4j-api:2.0.11",
         "org.slf4j:slf4j-jdk14:2.0.11",
     ],

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/client/BUILD.bazel
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/client/BUILD.bazel
@@ -5,12 +5,16 @@ kt_jvm_library(
     name = "client_lib",
     srcs = glob(["*.kt"]),
     visibility = ["//visibility:public"],
-    runtime_deps = ["@maven//:org_slf4j_slf4j_jdk14"],
     deps = [
         "//kotlin:balance_grpc_gen",
+        "//kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config:config_lib",
         "@maven//:com_github_ajalt_clikt_clikt_jvm",
         "@maven//:io_github_oshai_kotlin_logging_jvm",
         "@maven//:io_grpc_grpc_netty_shaded",
         "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm",
+    ],
+    runtime_deps = [
+        "@maven//:org_slf4j_slf4j_jdk14",
+        "//kotlin/src/main/resources:client_resources",
     ],
 )

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/client/client.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/client/client.kt
@@ -1,12 +1,13 @@
 package com.geekinasuit.polyglot.brackets.client
 
+import com.geekinasuit.polyglot.brackets.config.ClientAppConfig
+import com.geekinasuit.polyglot.brackets.config.ConfigCommand
+import com.geekinasuit.polyglot.brackets.config.loadConfig
 import com.geekinasuit.polyglot.brackets.service.protos.BalanceBracketsGrpcKt
 import com.geekinasuit.polyglot.brackets.service.protos.BalanceRequest
-import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.main
 import com.github.ajalt.clikt.parameters.arguments.argument
-import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.help
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.inputStream
@@ -16,24 +17,46 @@ import io.grpc.ManagedChannelBuilder
 import java.io.BufferedReader
 import kotlinx.coroutines.runBlocking
 
-private const val DEFAULT_HOST = "localhost"
-private const val DEFAULT_PORT = 8888
 private val log = KotlinLogging.logger {}
 
-class BracketsClient : CliktCommand(name = "brackets_client") {
-  val host by option().default(DEFAULT_HOST).help("Service IP port number")
-  val port by option().int().default(DEFAULT_PORT).help("Service IP port number")
+class BracketsClient : ConfigCommand<ClientAppConfig>("brackets_client") {
+  val host by option("--host").help("Server host (overrides config)")
+    .applyTo { copy(client = client.copy(host = it)) }
+  val port by option("--port").int().help("Server port (overrides config)")
+    .applyTo { copy(client = client.copy(port = it)) }
+  val environment by option("--environment").help("Deployment environment")
+    .applyTo { copy(client = client.copy(environment = it)) }
+  val instanceId by option("--instance-id").help("Unique instance identifier")
+    .applyTo { copy(client = client.copy(instanceId = it)) }
+  val otlpEndpoint by option("--otlp-endpoint")
+    .help("OTLP gRPC endpoint for traces+metrics (e.g. http://localhost:4317)")
+    .applyTo { copy(telemetry = telemetry.copy(otlpEndpoint = it)) }
+  val logEndpoint by option("--log-endpoint")
+    .help("OTLP gRPC endpoint for logs (defaults to --otlp-endpoint)")
+    .applyTo { copy(telemetry = telemetry.copy(logEndpoint = it)) }
   val text by argument().inputStream()
 
   override fun run(): Unit = runBlocking {
-    println("brackets client running...")
+    assertAllOptionsAreBound()
+    val config = resolveConfig(loadConfig("/client/application.yml"))
+
+    log.info {
+      "brackets client starting: target=${config.client.host}:${config.client.port} " +
+        "environment=${config.client.environment} instanceId=${config.client.instanceId} " +
+        "otlpEndpoint=${config.telemetry.otlpEndpoint ?: "(disabled)"}"
+    }
+
     val buffer = text.bufferedReader().use(BufferedReader::readText)
     text.close()
 
     println("About to check:\n========")
     println(buffer)
     println("========")
-    val channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build()
+
+    val channel =
+      ManagedChannelBuilder.forAddress(config.client.host, config.client.port)
+        .usePlaintext()
+        .build()
     val stub = BalanceBracketsGrpcKt.BalanceBracketsCoroutineStub(channel)
     val request = BalanceRequest.newBuilder().setStatement(buffer).build()
     val response =
@@ -45,7 +68,7 @@ class BracketsClient : CliktCommand(name = "brackets_client") {
         )
         throw ProgramResult(1)
       }
-    log.info { response }
+    log.info { "Response: succeeded=${response.succeeded} isBalanced=${response.isBalanced}" }
     when {
       !response.succeeded -> {
         System.err.println("Error balancing brackets: ${response.error}")

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config/BUILD.bazel
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+kt_jvm_library(
+    name = "config_lib",
+    srcs = glob(["*.kt"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "@maven//:com_github_ajalt_clikt_clikt_jvm",
+        "@maven//:com_sksamuel_hoplite_hoplite_core",
+        "@maven//:com_sksamuel_hoplite_hoplite_yaml",
+    ],
+)

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config/Config.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config/Config.kt
@@ -1,0 +1,72 @@
+package com.geekinasuit.polyglot.brackets.config
+
+/** Top-level config for the service binary. */
+data class ServiceAppConfig(
+  val service: ServiceConfig = ServiceConfig(),
+  val telemetry: TelemetryConfig = TelemetryConfig(),
+)
+
+/** Top-level config for the client binary. */
+data class ClientAppConfig(
+  val client: ClientConfig = ClientConfig(),
+  val telemetry: TelemetryConfig = TelemetryConfig(),
+)
+
+data class ServiceConfig(
+  val host: String = "localhost",
+  val port: Int = 8888,
+  val environment: String = defaultEnvironment(),
+  val instanceId: String = defaultInstanceId(),
+)
+
+data class ClientConfig(
+  val host: String = "localhost",
+  val port: Int = 8888,
+  val environment: String = defaultEnvironment(),
+  val instanceId: String = defaultInstanceId(),
+)
+
+data class TelemetryConfig(
+  /** OTLP gRPC endpoint for traces and metrics. Null disables OTLP export. */
+  val otlpEndpoint: String? = null,
+  /**
+   * OTLP gRPC endpoint for logs. Null falls back to [otlpEndpoint].
+   * See [effectiveLogEndpoint].
+   */
+  val logEndpoint: String? = null,
+  val metricsExportIntervalSeconds: Long = 60,
+  val tracingEnabled: Boolean = true,
+  val metricsEnabled: Boolean = true,
+  /** Disabled by default — must be explicitly opted in per environment. */
+  val loggingExportEnabled: Boolean = false,
+)
+
+/** Resolves the log OTLP endpoint, falling back to the main OTLP endpoint. */
+val TelemetryConfig.effectiveLogEndpoint: String?
+  get() = logEndpoint ?: otlpEndpoint
+
+/**
+ * Resolves the deployment environment from standard env vars, defaulting to "development".
+ * Checks DEPLOYMENT_ENV then ENVIRONMENT.
+ */
+fun defaultEnvironment(): String =
+  System.getenv("DEPLOYMENT_ENV") ?: System.getenv("ENVIRONMENT") ?: "development"
+
+/**
+ * Resolves a unique per-instance identifier using standard signals (first match wins):
+ *  - Kubernetes: $POD_NAME (inject via Downward API)
+ *  - Docker:     $HOSTNAME when it looks like a container ID (12–64 hex chars)
+ *  - Dev:        "$user@$hostname" — disambiguates concurrent local instances
+ *
+ * TODO: Become an @Inject constructor parameter when the Dagger ticket is implemented.
+ * See thoughts/shared/tickets/kotlin-dagger-grpc-di.md
+ */
+fun defaultInstanceId(): String {
+  System.getenv("POD_NAME")?.let { return it }
+  val hostname = System.getenv("HOSTNAME") ?: ""
+  if (hostname.matches(Regex("[a-f0-9]{12,64}"))) return hostname
+  val user = System.getProperty("user.name") ?: "unknown"
+  val host =
+    runCatching { java.net.InetAddress.getLocalHost().hostName }.getOrDefault("localhost")
+  return "$user@$host"
+}

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config/ConfigCommand.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config/ConfigCommand.kt
@@ -1,0 +1,96 @@
+package com.geekinasuit.polyglot.brackets.config
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.OptionWithValues
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+/**
+ * Base class for commands driven by a Hoplite config file with selective CLI overrides.
+ *
+ * Declare CLI options using [applyTo] to bind each option to a mutation on the config type [C].
+ * When the option is provided on the command line, the mutation fires; if absent, the config
+ * file value is left unchanged. Call [resolveConfig] inside [run] to obtain the final merged
+ * config after all CLI overrides have been applied.
+ *
+ * Example:
+ * ```kotlin
+ * class MyCommand : ConfigCommand<MyConfig>("my-command") {
+ *   val host by option("--host").applyTo { copy(server = server.copy(host = it)) }
+ *   val port by option("--port").int().applyTo { copy(server = server.copy(port = it)) }
+ *
+ *   override fun run() {
+ *     val config = resolveConfig(loadConfig("/my/application.yml"))
+ *   }
+ * }
+ * ```
+ *
+ * Validation: at startup, [assertAllOptionsAreBound] can be called to confirm every registered
+ * Clikt option has a corresponding [applyTo] binding. Any option declared without [applyTo]
+ * will be parsed and available, but its value will not be applied to the config automatically.
+ */
+abstract class ConfigCommand<C : Any>(name: String) : CliktCommand(name = name) {
+  private val mutations = mutableListOf<C.() -> C>()
+
+  /**
+   * Binds this option to a config mutation. When the option is provided on the CLI, [mutate]
+   * is invoked on the current config with the parsed value, and the result replaces the config.
+   * When the option is absent, [mutate] is not called and the config is unchanged.
+   *
+   * Returns a [ReadOnlyProperty] delegate; use with `by` as normal.
+   */
+  fun <T : Any> OptionWithValues<T?, T, T>.applyTo(
+    mutate: C.(T) -> C
+  ): MutatingOptionDelegate<T, C> = MutatingOptionDelegate(this, mutations, mutate)
+
+  /**
+   * Applies all registered CLI mutations to [base] in declaration order.
+   * Call this inside [run] after option parsing is complete.
+   */
+  protected fun resolveConfig(base: C): C = mutations.fold(base) { cfg, m -> cfg.m() }
+
+  /**
+   * Asserts that the number of registered [applyTo] bindings equals the number of non-eager
+   * options registered with Clikt. A mismatch means at least one option was declared without
+   * a corresponding config binding.
+   *
+   * Call early in [run] when you want startup-time validation.
+   */
+  protected fun assertAllOptionsAreBound() {
+    // Exclude Clikt's built-in eager options (--help, --version, etc.) from the count.
+    val userOptionCount =
+      registeredOptions().count { opt ->
+        opt.names.any { it.startsWith("--") } &&
+          opt.names.none { it == "--help" || it == "--version" }
+      }
+    check(userOptionCount == mutations.size) {
+      "Option/config binding mismatch: $userOptionCount option(s) registered, " +
+        "${mutations.size} applyTo binding(s) found. " +
+        "Every '--' option should use applyTo { } to bind it to the config."
+    }
+  }
+}
+
+/**
+ * A property delegate produced by [ConfigCommand.applyTo].
+ *
+ * When bound via `by`, it registers the underlying Clikt option with the command (so help text,
+ * parsing, and type coercion work as usual) and simultaneously registers a lazy mutation that
+ * reads the option's parsed value at [ConfigCommand.resolveConfig] time.
+ */
+class MutatingOptionDelegate<T : Any, C : Any>(
+  private val wrapped: OptionWithValues<T?, T, T>,
+  private val mutations: MutableList<C.() -> C>,
+  private val mutate: C.(T) -> C,
+) {
+  operator fun provideDelegate(
+    thisRef: ConfigCommand<C>,
+    prop: KProperty<*>,
+  ): ReadOnlyProperty<CliktCommand, T?> {
+    val inner = wrapped.provideDelegate(thisRef, prop)
+    mutations.add {
+      inner.getValue(thisRef, prop)?.let { v -> mutate(v) } ?: this
+    }
+    return inner
+  }
+}

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config/ConfigLoader.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config/ConfigLoader.kt
@@ -1,0 +1,30 @@
+package com.geekinasuit.polyglot.brackets.config
+
+import com.sksamuel.hoplite.ConfigLoaderBuilder
+import com.sksamuel.hoplite.addEnvironmentSource
+import com.sksamuel.hoplite.addResourceOrFileSource
+
+/**
+ * Builds a Hoplite config loader with layered sources (lowest → highest priority):
+ *   1. YAML resource file at [resourcePath] (optional; missing file is tolerated)
+ *   2. Environment variables
+ *
+ * CLI flag overrides are applied by callers after loading via data class copy().
+ *
+ * Extension seam: insert additional PropertySource implementations into this builder for:
+ *   - Secrets manager (e.g., AWS Secrets Manager, HashiCorp Vault)
+ *   - Feature flag overrides (e.g., LaunchDarkly)
+ * Sources added later in the builder chain take higher precedence.
+ *
+ * Note on env var naming: with useUnderscoresAsSeparator=true, single underscores act as
+ * path separators. This works cleanly for single-word nested keys (e.g., SERVICE_HOST →
+ * service.host, SERVICE_PORT → service.port). For multi-word camelCase fields, the CLI
+ * flags are the reliable override mechanism.
+ */
+fun buildConfigLoader(resourcePath: String): ConfigLoaderBuilder =
+  ConfigLoaderBuilder.default()
+    .addResourceOrFileSource(resourcePath, optional = true)
+    .addEnvironmentSource(useUnderscoresAsSeparator = true, allowUppercaseNames = true)
+
+inline fun <reified T : Any> loadConfig(resourcePath: String): T =
+  buildConfigLoader(resourcePath).build().loadConfigOrThrow()

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BUILD.bazel
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BUILD.bazel
@@ -5,15 +5,19 @@ kt_jvm_library(
     name = "service_lib",
     srcs = glob(["*.kt"]),
     visibility = ["//visibility:public"],
-    runtime_deps = ["@maven//:org_slf4j_slf4j_jdk14"],
     deps = [
         "//kotlin:balance_grpc_gen",
         "//kotlin/src/main/kotlin/bracketskt",
+        "//kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config:config_lib",
         "@grpc-java//stub",
         "@maven//:com_github_ajalt_clikt_clikt_jvm",
         "@maven//:com_linecorp_armeria_armeria",
         "@maven//:com_linecorp_armeria_armeria_grpc",
         "@maven//:io_github_oshai_kotlin_logging_jvm",
         "@maven//:io_grpc_grpc_api",
+    ],
+    runtime_deps = [
+        "@maven//:org_slf4j_slf4j_jdk14",
+        "//kotlin/src/main/resources:service_resources",
     ],
 )

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/service.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/service.kt
@@ -1,11 +1,11 @@
 package com.geekinasuit.polyglot.brackets.service
 
-import com.github.ajalt.clikt.core.CliktCommand
+import com.geekinasuit.polyglot.brackets.config.ConfigCommand
+import com.geekinasuit.polyglot.brackets.config.ServiceAppConfig
+import com.geekinasuit.polyglot.brackets.config.loadConfig
 import com.github.ajalt.clikt.core.main
-import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.help
 import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.types.boolean
 import com.github.ajalt.clikt.parameters.types.int
 import com.linecorp.armeria.server.Server
 import com.linecorp.armeria.server.grpc.GrpcService
@@ -13,17 +13,36 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import io.grpc.BindableService
 import io.grpc.ServerInterceptor
 
-private const val DEFAULT_HOST = "localhost"
-private const val DEFAULT_PORT = 8888
 private val log = KotlinLogging.logger {}
 
-class BracketsService : CliktCommand(name = "brackets_service") {
-  val host by option().default(DEFAULT_HOST).help("Service Hostname")
-  val port: Int by option().int().default(DEFAULT_PORT).help("Service IP port number")
+class BracketsService : ConfigCommand<ServiceAppConfig>("brackets_service") {
+  val host by option("--host").help("Bind host (overrides config)")
+    .applyTo { copy(service = service.copy(host = it)) }
+  val port by option("--port").int().help("Bind port (overrides config)")
+    .applyTo { copy(service = service.copy(port = it)) }
+  val environment by option("--environment").help("Deployment environment")
+    .applyTo { copy(service = service.copy(environment = it)) }
+  val instanceId by option("--instance-id").help("Unique instance identifier")
+    .applyTo { copy(service = service.copy(instanceId = it)) }
+  val otlpEndpoint by option("--otlp-endpoint")
+    .help("OTLP gRPC endpoint for traces+metrics (e.g. http://localhost:4317)")
+    .applyTo { copy(telemetry = telemetry.copy(otlpEndpoint = it)) }
+  val logEndpoint by option("--log-endpoint")
+    .help("OTLP gRPC endpoint for logs (defaults to --otlp-endpoint)")
+    .applyTo { copy(telemetry = telemetry.copy(logEndpoint = it)) }
 
   override fun run() {
-    println("brackets service starting...")
-    val server = Server.builder().http(port).service(wrapService(BalanceServiceEndpoint())).build()
+    assertAllOptionsAreBound()
+    val config = resolveConfig(loadConfig("/service/application.yml"))
+
+    log.info {
+      "brackets service starting: host=${config.service.host} port=${config.service.port} " +
+        "environment=${config.service.environment} instanceId=${config.service.instanceId} " +
+        "otlpEndpoint=${config.telemetry.otlpEndpoint ?: "(disabled)"}"
+    }
+
+    val server =
+      Server.builder().http(config.service.port).service(wrapService(BalanceServiceEndpoint())).build()
     server.closeOnJvmShutdown().thenRun { log.info { "Server has been stopped." } }
     server.start().join()
   }

--- a/kotlin/src/main/resources/BUILD.bazel
+++ b/kotlin/src/main/resources/BUILD.bazel
@@ -1,0 +1,13 @@
+java_library(
+    name = "service_resources",
+    resources = ["service/application.yml"],
+    resource_strip_prefix = "kotlin/src/main/resources",
+    visibility = ["//visibility:public"],
+)
+
+java_library(
+    name = "client_resources",
+    resources = ["client/application.yml"],
+    resource_strip_prefix = "kotlin/src/main/resources",
+    visibility = ["//visibility:public"],
+)

--- a/kotlin/src/main/resources/client/application.yml
+++ b/kotlin/src/main/resources/client/application.yml
@@ -1,0 +1,10 @@
+client:
+  host: localhost
+  port: 8888
+
+telemetry:
+  metrics-export-interval-seconds: 60
+  tracing-enabled: true
+  metrics-enabled: true
+  logging-export-enabled: false
+  # otlp-endpoint and log-endpoint are absent by default (null = no OTLP export)

--- a/kotlin/src/main/resources/service/application.yml
+++ b/kotlin/src/main/resources/service/application.yml
@@ -1,0 +1,10 @@
+service:
+  host: localhost
+  port: 8888
+
+telemetry:
+  metrics-export-interval-seconds: 60
+  tracing-enabled: true
+  metrics-enabled: true
+  logging-export-enabled: false
+  # otlp-endpoint and log-endpoint are absent by default (null = no OTLP export)

--- a/thoughts/shared/plans/2026-03-07-kotlin-otel-instrumentation.md
+++ b/thoughts/shared/plans/2026-03-07-kotlin-otel-instrumentation.md
@@ -1,0 +1,583 @@
+# Kotlin OpenTelemetry Instrumentation Plan
+
+## Overview
+
+Add full OpenTelemetry observability (traces, metrics, structured logs) to the Kotlin gRPC
+service and client, exporting via OTLP to a SigNoz instance. Includes a
+layered configuration system (Hoplite), structured JSON logging (Logback), instance
+identification, and environment labeling — all using OTel semantic conventions and W3C
+Trace Context propagation.
+
+DI wiring (Dagger) is explicitly out of scope and tracked separately in
+`thoughts/shared/tickets/kotlin-dagger-grpc-di.md`.
+
+## Current State Analysis
+
+- **Clikt already present in both binaries** — `BracketsService` and `BracketsClient` both
+  extend `CliktCommand`. No new CLI library needed; new options are added to the existing
+  commands.
+- `wrapService()` (`service.kt:34-39`) accepts `vararg interceptors: ServerInterceptor` and
+  passes them through to Armeria's `GrpcService.builder().intercept()`. The server interceptor
+  hook is fully ready.
+- `ManagedChannelBuilder` in `client.kt:36` is built without interceptors — client hook is
+  a one-line `.intercept(...)` addition before `.build()`.
+- Both binaries use `kotlin-logging` (SLF4J wrapper), with `slf4j-jdk14` as the runtime
+  backend. This is replaced with Logback for structured JSON output.
+- No configuration system exists — everything is hardcoded constants or minimal Clikt options.
+- gRPC-java version in use is **1.71.0**, which includes the stable `io.grpc:grpc-opentelemetry`
+  module (introduced in 1.65). No `-alpha`-suffixed library is needed for gRPC tracing.
+
+## Desired End State
+
+After this plan is complete:
+
+1. Both binaries read configuration from a layered system: HOCON config file → environment
+   variables → CLI flags.
+2. All logging is structured JSON to stdout, and optionally also exported via OTLP to SigNoz.
+3. Both binaries emit OTel traces with W3C `traceparent` propagated through gRPC metadata.
+4. Both binaries emit OTel metrics (request counts, latency histograms).
+5. OTel resources carry `service.name`, `deployment.environment`, and `service.instance.id`
+   with smart defaulting for dev vs. container environments.
+6. A configured SigNoz instance shows correlated traces across client and server, with logs
+   attached to spans via matching `trace_id`. The endpoint is supplied via
+   `TELEMETRY_OTLP_ENDPOINT` or `--otlp-endpoint`; no hostname is hardcoded.
+
+### End-to-end verification
+
+```bash
+bazel build //kotlin:brackets_service //kotlin:brackets_client
+
+# Start server (SigNoz export enabled)
+TELEMETRY_OTLP_ENDPOINT=http://localhost:4317 bazel run //kotlin:brackets_service
+
+# Make a call
+echo "(hello [world])" | TELEMETRY_OTLP_ENDPOINT=http://localhost:4317 \
+  bazel run //kotlin:brackets_client -- /dev/stdin
+```
+
+Expected in SigNoz: three-level span hierarchy, request count metric increments,
+structured logs with `trace_id` correlating to the visible trace.
+
+## What We Are NOT Doing
+
+- No DI framework (Dagger) in this plan — see `thoughts/shared/tickets/kotlin-dagger-grpc-di.md`.
+- No instrumentation of other languages (Go, Java, Python, Rust).
+- No distributed context propagation beyond the single client→server hop.
+- No OTel sampling configuration — always-on sampling is appropriate at this scale.
+- No secrets manager integration — only the extension seam is designed in the config loader.
+- No LaunchDarkly / feature flag integration — only the seam.
+- No `service.version` attribute — no build version system exists yet.
+- No Armeria HTTP client tracing — the client uses grpc-netty-shaded directly.
+
+## Key Discoveries
+
+- `wrapService()` vararg hook (`service.kt:34-39`) is the exact injection point for the
+  gRPC server interceptor. Only the call site at `service.kt:26` needs to change.
+- `io.grpc:grpc-opentelemetry:1.71.0` (stable) provides `GrpcOpenTelemetry` with both
+  `newServerInterceptor()` and `newClientInterceptor()`. W3C TraceContext propagation
+  through gRPC metadata is handled automatically.
+- `armeria-opentelemetry:1.26.4` provides `OpenTelemetryService.newDecorator()` for
+  HTTP/2-layer spans, and the `Server.builder()` API has a `serverListener()` hook for
+  lifecycle events (`serverStarted`, `serverStopping`, `serverStopped`).
+- `opentelemetry-sdk` is an umbrella artifact covering trace, metrics, and logs SDK
+  components — one artifact covers all three signals.
+- `opentelemetry-exporter-otlp` covers OTLP gRPC export for all three signals.
+- `slf4j-jdk14` is in `runtime_deps` of both `service/BUILD.bazel` and `client/BUILD.bazel`
+  — straightforward swap for Logback.
+- Hoplite's `PropertySource` interface is the extension point for future secrets manager
+  and feature flag sources.
+
+## Trace Hierarchy
+
+The intended span structure for each server-side RPC:
+
+```
+[Armeria HTTP/2 span]                       ← armeria-opentelemetry, http.* attributes
+  └─ [gRPC: BalanceBrackets/Balance]         ← grpc-opentelemetry interceptor, rpc.* attributes
+       └─ [balance-brackets]                 ← manual span, statement + result attributes
+```
+
+The client emits a root span; W3C `traceparent` links it to the Armeria span on the server.
+
+## Instance Identification
+
+| Context     | `service.instance.id` value                      |
+|-------------|--------------------------------------------------|
+| Kubernetes  | `$POD_NAME` (inject via Downward API)            |
+| Docker      | `$HOSTNAME` when it matches a container ID regex |
+| Dev (local) | `$user@$hostname` — disambiguates local replicas |
+| Explicit    | `--instance-id` flag or `SERVICE_INSTANCE_ID` env var |
+
+Detection is attempted in order; first match wins.
+
+---
+
+## Phase 1: Configuration System (Hoplite)
+
+### Overview
+
+Introduce a layered config system using Hoplite with YAML format. The source priority is:
+YAML file (lowest) → environment variables → CLI flags (highest). The config loader is
+built through a factory function that acts as an extension seam — future callers insert
+additional `PropertySource` implementations here (secrets manager, feature flags) without
+changing any call sites.
+
+Config data classes use a nested structure with a shared `TelemetryConfig` and
+binary-specific root configs (`ServiceAppConfig`, `ClientAppConfig`). The service-specific
+and client-specific sections each compute smart defaults for `environment` (checking
+standard env vars before falling back to `"development"`) and `instanceId` (checking
+Kubernetes, Docker, and local signals in order).
+
+Clikt options in both commands become nullable overrides — a `null` value means "use the
+config file / env var value". After loading config from Hoplite, the Clikt layer applies
+non-null overrides via data class `copy()`.
+
+### New Maven Artifacts
+
+```
+"com.sksamuel.hoplite:hoplite-core:2.9.0",
+"com.sksamuel.hoplite:hoplite-yaml:2.9.0",
+```
+
+### New Files
+
+- **`kotlin/.../brackets/config/Config.kt`** — data classes: `ServiceAppConfig`,
+  `ClientAppConfig`, `ServiceConfig`, `ClientConfig`, `TelemetryConfig`. Top-level functions
+  for environment and instance ID defaulting.
+- **`kotlin/.../brackets/config/ConfigLoader.kt`** — `buildConfigLoader()` factory function
+  composing an environment variable source and a YAML resource file source (optional, so
+  a missing file is tolerated). The function's docstring calls out where to insert secrets
+  and feature flag sources.
+- **`kotlin/.../brackets/config/BUILD.bazel`** — `kt_jvm_library` with Hoplite deps.
+- **`kotlin/src/main/resources/service/application.yml`** — YAML defaults for the service.
+- **`kotlin/src/main/resources/client/application.yml`** — YAML defaults for the client.
+- **`kotlin/src/main/resources/BUILD.bazel`** — `java_library` resource targets for each
+  binary, using `resource_strip_prefix = "kotlin/src/main/resources"` so `application.yml`
+  lands at the classpath root. The `logback.xml` added in Phase 2 is also included here.
+
+### YAML defaults (both files share this telemetry block)
+
+```yaml
+telemetry:
+  otlp-endpoint: null
+  log-endpoint: null
+  metrics-export-interval-seconds: 60
+  tracing-enabled: true
+  metrics-enabled: true
+  logging-export-enabled: false
+```
+
+### Changes to Existing Files
+
+- `service.kt` — replace the two hardcoded constants and two Clikt options with nullable
+  CLI overrides for all `ServiceConfig` and `TelemetryConfig` fields. Load config at the
+  top of `run()` and apply CLI overrides via `copy()`.
+- `client.kt` — same pattern with `ClientAppConfig`.
+- `service/BUILD.bazel` and `client/BUILD.bazel` — add `config_lib` to `deps` and the
+  appropriate resource target to `runtime_deps`.
+
+### Success Criteria
+
+- `bazel build //kotlin:brackets_service //kotlin:brackets_client` passes.
+- `--host` / `--port` CLI flags override config file values at runtime.
+- Setting `SERVICE_HOST=myhost` env var changes the bind host without a code change.
+- Missing `application.conf` is tolerated (Hoplite source marked optional).
+
+**Pause here for human confirmation before proceeding to Phase 2.**
+
+---
+
+## Phase 2: Structured Logging (Logback + JSON)
+
+### Overview
+
+Replace the `slf4j-jdk14` JUL backend with Logback Classic and the Logstash JSON encoder.
+All log output becomes structured JSON on stdout — the standard format for log aggregators
+and OTel log collectors. The OTel logback appender is added and declared in `logback.xml`
+but is a no-op until the OTel SDK is installed in Phase 3; it silently drops events until
+`OpenTelemetryAppender.install(sdk)` is called.
+
+The logback config captures `trace_id`, `span_id`, and `trace_flags` from MDC — these are
+injected by the OTel logback appender when a span is active, enabling log-to-trace
+correlation in SigNoz.
+
+The bare `println("brackets service starting...")` and `println("brackets client running...")`
+calls are replaced with `log.info {}` calls. The `println` calls used for user-facing output
+(the statement display block with `========` separators) are intentional terminal output
+and remain unchanged.
+
+### New Maven Artifacts
+
+```
+"ch.qos.logback:logback-classic:1.5.16",
+"net.logstash.logback:logstash-logback-encoder:8.0",
+"io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0:2.14.0-alpha",
+```
+
+Note: the `-alpha` suffix on the logback appender artifact reflects API-stability status,
+not production readiness. This artifact is widely used in production JVM services.
+
+Remove from `maven.install`:
+```
+"org.slf4j:slf4j-jdk14:2.0.11",   ← replaced by logback-classic; keep slf4j-api
+```
+
+### New Files
+
+- **`kotlin/src/main/resources/logback.xml`** — configures two appenders:
+  - `LogstashConsoleAppender` with `LogstashEncoder` (JSON stdout, always active).
+  - `OpenTelemetryAppender` (no-op until SDK is installed; captures MDC keys `trace_id`,
+    `span_id`, `trace_flags`; `captureExperimentalAttributes` and `captureCodeAttributes`
+    enabled). Both appenders are attached to the root logger at INFO level.
+
+### Changes to Existing Files
+
+- `service/BUILD.bazel` and `client/BUILD.bazel` — replace `@maven//:org_slf4j_slf4j_jdk14`
+  in `runtime_deps` with `logback-classic`, `logstash-logback-encoder`, and the OTel logback
+  appender artifact.
+- `src/main/resources/BUILD.bazel` (from Phase 1) — add `logback.xml` to both resource
+  targets so it lands at the classpath root for both binaries.
+- `service.kt` — replace `println("brackets service starting...")` with `log.info {}`.
+- `client.kt` — replace `println("brackets client running...")` with `log.info {}`.
+
+### Success Criteria
+
+- Log output is valid JSON with `@timestamp`, `level`, `logger_name`, `message` fields.
+- No JUL-formatted lines in stdout.
+- `bazel build //kotlin:brackets_service //kotlin:brackets_client` passes.
+
+**Pause here for human confirmation before proceeding to Phase 3.**
+
+---
+
+## Phase 3: OpenTelemetry SDK Setup
+
+### Overview
+
+Add the OTel SDK and create a shared `TelemetrySetup.kt` that initialises all three signals
+(traces, metrics, logs) and registers the SDK globally. Resource attributes are set from
+the config: `service.name` is passed as a parameter; `deployment.environment` and
+`service.instance.id` come from the resolved config. OTLP export is conditional — if no
+endpoint is configured, each provider uses a no-op exporter so in-process instrumentation
+still functions without an external collector.
+
+After SDK registration, `OpenTelemetryAppender.install(sdk)` is called to activate the
+logback appender declared in Phase 2. From this point on, log lines emitted while a span is
+active will carry `trace_id` and `span_id` in both the JSON console output (via MDC) and in
+OTLP log export (if enabled).
+
+The metrics export interval is read from `TelemetryConfig.metricsExportIntervalSeconds`
+rather than hardcoded, so it is tunable per environment via config or env var.
+
+`TelemetryConfig.logEndpoint` falls back to `otlpEndpoint` if not explicitly set — an
+extension property (`effectiveLogEndpoint`) encapsulates this logic.
+
+`initTelemetry()` returns the `GrpcOpenTelemetry` handle so callers can obtain gRPC
+interceptors from it directly. Future DI refactoring (see the Dagger ticket) will provide
+this as an injected type instead.
+
+### New Maven Artifacts
+
+```
+"io.opentelemetry:opentelemetry-api:1.47.0",
+"io.opentelemetry:opentelemetry-sdk:1.47.0",           # umbrella: trace + metrics + logs SDKs
+"io.opentelemetry:opentelemetry-exporter-otlp:1.47.0", # covers all three signals via OTLP gRPC
+"io.grpc:grpc-opentelemetry:1.71.0",                   # stable; matches existing grpc-java version
+```
+
+### New Files
+
+- **`kotlin/.../brackets/telemetry/TelemetrySetup.kt`** — `initTelemetry(serviceName,
+  environment, instanceId, config)` function. Constructs and globally registers an
+  `OpenTelemetrySdk` with:
+  - `SdkTracerProvider` with optional `OtlpGrpcSpanExporter` + `BatchSpanProcessor`.
+  - `SdkMeterProvider` with optional `OtlpGrpcMetricExporter` + `PeriodicMetricReader`
+    (interval from config).
+  - `SdkLoggerProvider` with optional `OtlpGrpcLogRecordExporter` + `BatchLogRecordProcessor`
+    (conditional on `loggingExportEnabled` and `effectiveLogEndpoint`).
+  - W3C Trace Context propagation (`W3CTraceContextPropagator`).
+  - Resource attributes: `service.name`, `deployment.environment`, `service.instance.id`.
+  - Calls `OpenTelemetryAppender.install(sdk)` after registration.
+  - Returns `GrpcOpenTelemetry` built from the registered global SDK.
+- **`kotlin/.../brackets/telemetry/BUILD.bazel`** — `kt_jvm_library` with OTel and config
+  deps.
+
+### Changes to Existing Files
+
+- `service/BUILD.bazel` and `client/BUILD.bazel` — add `telemetry_lib` to `deps`.
+
+### Success Criteria
+
+- `bazel build //kotlin/src/main/kotlin/.../telemetry:telemetry_lib` passes.
+- Both binaries start without errors when no OTLP endpoint is configured.
+- A structured log line confirming SDK initialisation appears at startup, including the
+  resolved otlpEndpoint value (or `(disabled)` if null).
+
+**Pause here for human confirmation before proceeding to Phase 4.**
+
+---
+
+## Phase 4: Server Instrumentation (Traces + Metrics)
+
+### Overview
+
+Wire the OTel gRPC server interceptor and the Armeria HTTP/2 OTel decorator into the server,
+add a `ServerListener` for lifecycle logging, add a manual child span inside
+`BalanceServiceEndpoint`, and add OTel metrics instruments for request counting and latency.
+
+### Trace layering
+
+`OpenTelemetryService.newDecorator(otel)` wraps the `GrpcService` at the Armeria HTTP/2
+layer, producing a span with `http.*` semantic attributes. The gRPC server interceptor
+(from `grpcOtel.newServerInterceptor()`) produces a child span with `rpc.*` attributes.
+The manual `balance-brackets` span is a child of the gRPC span. Together these form the
+three-level hierarchy described in the overview.
+
+### New Maven Artifact
+
+```
+"com.linecorp.armeria:armeria-opentelemetry:1.26.4",
+```
+
+### Changes to `service.kt`
+
+- Call `initTelemetry()` early in `run()` using the resolved config, passing
+  `"brackets-service"` as the service name. Log all resolved config values at this point
+  (host, port, environment, instanceId, otlpEndpoint).
+- Pass `grpcOtel.newServerInterceptor()` into the existing `wrapService()` call.
+- Apply `OpenTelemetryService.newDecorator(otel)` as a service decorator on the
+  `Server.builder()`, layered above the `GrpcService`.
+- Add a `ServerListenerAdapter` to the server builder with:
+  - `serverStarted()` — log confirmed active ports; end the startup OTel span here.
+  - `serverStopping()` — log graceful drain start.
+  - `serverStopped()` — log shutdown confirmed.
+- Wrap the server construction and startup in a manual `server.startup` OTel span. The span
+  starts before `Server.builder()` and ends inside `serverStarted()` so it measures actual
+  Armeria initialization time including port binding. If startup throws before
+  `serverStarted()` fires, the span must be ended in a catch block.
+- Remove the existing `server.closeOnJvmShutdown().thenRun { log.info { ... } }` pattern;
+  shutdown logging moves into the `ServerListener`.
+
+### Changes to `service/BUILD.bazel`
+
+Add `config_lib`, `telemetry_lib`, `armeria-opentelemetry`, and `opentelemetry-api` to
+`deps`. Add resource target from Phase 1 to `runtime_deps`.
+
+### Changes to `BalanceServiceEndpoint.kt`
+
+`BalanceServiceEndpoint` gains `Tracer` and `Meter` fields obtained from `GlobalOpenTelemetry`
+at construction time (a TODO comment notes these should become `@Inject` constructor
+parameters when the Dagger ticket is implemented).
+
+For each `balance()` call, the endpoint:
+- Creates a child span named `balance-brackets`, setting `statement.length` and
+  `statement.text` as span attributes before starting the algorithm.
+- Runs `balancedBrackets()` inside `span.makeCurrent().use { ... }` so that log lines
+  emitted from the algorithm carry the span's trace context in MDC.
+- On completion, sets a `result` span attribute: `"balanced"`, `"not_balanced"`, or `"error"`.
+  On unexpected exceptions, also calls `span.setStatus(StatusCode.ERROR, message)`.
+- Always ends the span in a `finally` block.
+- Increments a `brackets.server.request.count` counter with a `result` dimension label.
+- Records a `brackets.server.request.duration.ms` histogram observation.
+
+### Success Criteria
+
+- `bazel build //kotlin:brackets_service` passes.
+- Startup log contains all config values in JSON format.
+- `serverStarted` log line shows confirmed active ports.
+- After a client call, SigNoz Traces shows the three-level span hierarchy.
+- Span attributes `statement.length`, `statement.text`, and `result` are visible.
+- `brackets.server.request.count` metric appears in SigNoz with a `result` label.
+
+**Pause here for human confirmation before proceeding to Phase 5.**
+
+---
+
+## Phase 5: Client Instrumentation (Traces + Metrics)
+
+### Overview
+
+Wire the OTel gRPC client interceptor into `ManagedChannelBuilder` and add startup logging
+and a request counter metric. The client interceptor automatically injects the W3C
+`traceparent` header into outgoing gRPC metadata, making the client's outbound span the
+parent of the Armeria HTTP/2 span on the server. No changes to the gRPC stub or request
+construction are needed — context propagation is entirely handled by the interceptor.
+
+### Changes to `client.kt`
+
+- Call `initTelemetry()` early in `run()` using the resolved config, passing
+  `"brackets-client"` as the service name. Log all resolved config values at this point.
+- Add `grpcOtel.newClientInterceptor()` to `ManagedChannelBuilder` via `.intercept(...)`
+  before `.build()`.
+- Log the statement length before sending the request.
+- Replace `log.info { response }` with a structured log of the individual response fields.
+- Increment a `brackets.client.call.count` counter after the call completes (or on
+  connection error), with a `result` label using the same value set as the server counter.
+
+### Changes to `client/BUILD.bazel`
+
+Add `config_lib`, `telemetry_lib`, and `opentelemetry-api` to `deps`. Add resource target
+from Phase 1 to `runtime_deps`.
+
+### Success Criteria
+
+- `bazel build //kotlin:brackets_client` passes.
+- In SigNoz Traces, a single trace shows the client span as root with Armeria and gRPC
+  spans on the server side as descendants — all sharing the same trace ID.
+- `brackets.client.call.count` metric appears in SigNoz with a `result` label.
+- Startup log shows target host, port, environment, instanceId in JSON format.
+
+**Pause here for human confirmation before proceeding to Phase 6.**
+
+---
+
+## Phase 6: OpenTelemetry Log Export Verification
+
+### Overview
+
+No new code. The OTel logback appender was declared in `logback.xml` (Phase 2) and activated
+by `OpenTelemetryAppender.install(sdk)` in `TelemetrySetup.kt` (Phase 3). This phase
+validates end-to-end log export and confirms log-to-trace correlation in SigNoz.
+
+Log export is disabled by default (`logging-export-enabled = false`). To enable it, set the
+flag in `application.conf` or via the `TELEMETRY_LOGGING_EXPORT_ENABLED` env var. The log
+OTLP endpoint defaults to `otlpEndpoint` if `log-endpoint` is not set explicitly.
+
+### Verification
+
+- Start the server with an OTLP endpoint and logging export enabled.
+- Make a client call.
+- In SigNoz Logs: structured log entries appear with a `trace_id` matching spans visible in
+  SigNoz Traces.
+- Clicking a log entry in SigNoz navigates to the associated trace span.
+- JSON console logs on stdout include `trace_id` and `span_id` in the JSON envelope for log
+  lines emitted while a span is active.
+
+---
+
+## Testing Strategy
+
+Automated testing for telemetry uses two tiers. Manual SigNoz verification (Phase 6) is a
+third, separate concern and is not a substitute for the automated tiers.
+
+### Tier 1: Unit tests with in-memory exporters
+
+`io.opentelemetry:opentelemetry-sdk-testing` provides `InMemorySpanExporter`,
+`InMemoryMetricReader`, and `InMemoryLogRecordExporter`. These are wired into the OTel SDK
+in place of the OTLP exporters during tests, making assertions fully in-process with no
+network or Docker requirement.
+
+Key assertions to cover in unit tests (in the existing `BracketsTest` target or a new
+`TelemetryTest` target under `kotlin/src/test/kotlin/`):
+
+- `BalanceServiceEndpoint.balance()` emits a span named `balance-brackets`.
+- The span carries `statement.length`, `statement.text`, and `result` attributes.
+- `result` is `"balanced"` for valid balanced input, `"not_balanced"` for imbalanced input,
+  and `"error"` for unexpected exceptions.
+- On unexpected exceptions, span status is `ERROR`.
+- `brackets.server.request.count` counter increments with the correct `result` label.
+
+New maven artifact (test-only):
+```
+"io.opentelemetry:opentelemetry-sdk-testing:1.47.0",  # testonly
+```
+
+### Tier 2: Integration test with OTel Collector via Testcontainers
+
+For end-to-end validation of the full OTLP pipeline without a real SigNoz, use
+**Testcontainers** to start an `otel/opentelemetry-collector` container per test run.
+The collector is configured with an `otlp` receiver and a `file` exporter writing OTLP
+JSON to a temp directory, which the test can then assert against.
+
+The test starts the gRPC service with the collector's exposed port as the OTLP endpoint,
+runs a client call, waits briefly for the batch export flush, and asserts that the output
+file contains spans with the expected structure.
+
+This test should be tagged `requires-docker` and `local` in its Bazel rule to opt out of
+the sandbox (Bazel sandboxing blocks Docker socket access). It runs in CI as a separate
+step, not as part of `bazel test //...`.
+
+New maven artifacts (test-only):
+```
+"org.testcontainers:testcontainers:1.20.4",  # testonly
+"org.testcontainers:junit-4:1.20.4",         # testonly
+```
+
+A collector config YAML file should be added under `kotlin/src/test/resources/` with an
+`otlp` receiver on `0.0.0.0:4317` and a `file` exporter. The Bazel test target includes
+this file as a resource.
+
+### Out of scope: cross-language e2e matrix
+
+A scheduled test running all combinations of `(language X client) → (language Y service)`
+is tracked separately in `thoughts/shared/tickets/cross-language-e2e-matrix.md`. It is
+intentionally excluded from CI (too expensive per-PR) and will run on a schedule once
+multiple languages have full gRPC client/server implementations.
+
+---
+
+## Configuration Reference
+
+| Config key | Env var | CLI flag | Default |
+|---|---|---|---|
+| `service.host` | `SERVICE_HOST` | `--host` | `localhost` |
+| `service.port` | `SERVICE_PORT` | `--port` | `8888` |
+| `service.environment` | `DEPLOYMENT_ENV` / `ENVIRONMENT` | `--environment` | `development` |
+| `service.instance-id` | `SERVICE_INSTANCE_ID` / `POD_NAME` | `--instance-id` | `user@hostname` |
+| `telemetry.otlp-endpoint` | `TELEMETRY_OTLP_ENDPOINT` | `--otlp-endpoint` | `null` |
+| `telemetry.log-endpoint` | `TELEMETRY_LOG_ENDPOINT` | `--log-endpoint` | `null` (falls back to `otlp-endpoint`) |
+| `telemetry.metrics-export-interval-seconds` | `TELEMETRY_METRICS_EXPORT_INTERVAL_SECONDS` | _(config only)_ | `60` |
+| `telemetry.logging-export-enabled` | `TELEMETRY_LOGGING_EXPORT_ENABLED` | _(config only)_ | `false` |
+
+## Maven Artifacts Summary
+
+**Add to `MODULE.bazel`:**
+```
+# Configuration
+"com.sksamuel.hoplite:hoplite-core:2.9.0",
+"com.sksamuel.hoplite:hoplite-yaml:2.9.0",
+
+# Structured logging (opentelemetry-logback-appender-1.0 carries -alpha API-stability marker)
+"ch.qos.logback:logback-classic:1.5.16",
+"net.logstash.logback:logstash-logback-encoder:8.0",
+"io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0:2.14.0-alpha",
+
+# OpenTelemetry SDK (opentelemetry-sdk covers trace + metrics + logs)
+"io.opentelemetry:opentelemetry-api:1.47.0",
+"io.opentelemetry:opentelemetry-sdk:1.47.0",
+"io.opentelemetry:opentelemetry-exporter-otlp:1.47.0",
+
+# gRPC OTel integration — stable; version matches existing grpc-java 1.71.0
+"io.grpc:grpc-opentelemetry:1.71.0",
+
+# Armeria OTel integration — HTTP/2-layer spans and lifecycle listener hooks
+"com.linecorp.armeria:armeria-opentelemetry:1.26.4",
+```
+
+**Remove from `MODULE.bazel`:**
+```
+"org.slf4j:slf4j-jdk14:2.0.11",   ← replaced by logback-classic; slf4j-api stays
+```
+
+## New File Summary
+
+| File | Purpose |
+|------|---------|
+| `kotlin/.../brackets/config/Config.kt` | Config data classes; env and instance ID defaulting logic |
+| `kotlin/.../brackets/config/ConfigLoader.kt` | Hoplite loader factory (secrets/feature-flag seam) |
+| `kotlin/.../brackets/config/BUILD.bazel` | `config_lib` |
+| `kotlin/.../brackets/telemetry/TelemetrySetup.kt` | OTel SDK init, all three signals, OTLP exporters |
+| `kotlin/.../brackets/telemetry/BUILD.bazel` | `telemetry_lib` |
+| `kotlin/src/main/resources/logback.xml` | JSON console appender + OTel logback appender |
+| `kotlin/src/main/resources/service/application.yml` | Service YAML defaults |
+| `kotlin/src/main/resources/client/application.yml` | Client YAML defaults |
+| `kotlin/src/main/resources/BUILD.bazel` | Resource targets with `resource_strip_prefix` |
+
+## References
+
+- Ticket (DI follow-up): `thoughts/shared/tickets/kotlin-dagger-grpc-di.md`
+- Ticket (interceptors): `thoughts/shared/tickets/kotlin-grpc-interceptors-not-implemented.md`
+- Codebase overview: `thoughts/shared/research/2026-03-05-polyglot-codebase-overview.compressed.md`
+- OTel gRPC Java: https://grpc.io/docs/languages/java/opentelemetry/
+- W3C Trace Context: https://www.w3.org/TR/trace-context/
+- Hoplite: https://github.com/sksamuel/hoplite

--- a/thoughts/shared/tickets/cross-language-e2e-matrix.md
+++ b/thoughts/shared/tickets/cross-language-e2e-matrix.md
@@ -1,0 +1,48 @@
+---
+date: 2026-03-08
+status: open
+priority: low
+area: testing, ci, grpc, multi-language
+---
+
+# Cross-language gRPC client/server e2e matrix test
+
+## Summary
+
+Once multiple languages have full gRPC client and server implementations, run a scheduled
+matrix test that validates every `(client language) × (server language)` combination talks
+to each other correctly over the wire.
+
+## Motivation
+
+The polyglot project's core claim is that the gRPC contract defined in `//protobuf:balance_rpc`
+is language-agnostic. Today only Kotlin has both a client and a server. As Go, Java, Python,
+and Rust gain full gRPC implementations (see their respective tickets), we need a way to
+confirm cross-language interoperability is maintained — not just within a language.
+
+## Proposed Approach
+
+- A matrix workflow (GitHub Actions or Buildkite) parameterised by `client_lang` and
+  `server_lang`.
+- For each pair: start the server binary, run the client binary against it, assert on exit
+  code and stdout.
+- Run on a schedule (e.g. nightly or weekly), not per-PR — the test is too expensive to
+  block merges.
+- As languages are added to the matrix, the workflow is updated; the test itself does not
+  need to change.
+
+## Prerequisites
+
+The following tickets must be substantially complete before the matrix is meaningful:
+
+- `thoughts/shared/tickets/go-grpc-client-server.md`
+- `thoughts/shared/tickets/java-grpc-client-server.md`
+- `thoughts/shared/tickets/python-grpc-client-server.md`
+- `thoughts/shared/tickets/rust-grpc-client-server.md`
+
+## Context
+
+Deferred from the Kotlin OTel instrumentation plan
+(`thoughts/shared/plans/2026-03-07-kotlin-otel-instrumentation.md`) to keep that plan
+focused. The Testcontainers-based OTel integration test in that plan is a related but
+separate concern.

--- a/thoughts/shared/tickets/kotlin-dagger-grpc-di.md
+++ b/thoughts/shared/tickets/kotlin-dagger-grpc-di.md
@@ -1,0 +1,48 @@
+---
+date: 2026-03-07
+status: open
+priority: low
+area: kotlin, grpc, di
+---
+
+# Kotlin: Introduce Dagger DI via dagger-grpc integration
+
+## Summary
+
+The Kotlin service and client currently wire all objects manually (hardcoded construction
+in `run()` methods). As the project grows — particularly with the OTel telemetry subsystem,
+configuration objects, and potentially auth/interceptor chains — this becomes hard to test
+and hard to extend.
+
+Introduce Dagger 2 as the compile-time DI framework, using the `dagger-grpc` integration
+library to handle the gRPC/Armeria-specific binding concerns.
+
+## Context
+
+This was explicitly deferred from the OTel instrumentation plan
+(`thoughts/shared/plans/2026-03-07-kotlin-otel-instrumentation.md`) to keep that plan
+focused. The OTel plan was written without Dagger; it leaves construction in `run()` methods.
+When this ticket is implemented, the OTel modules (`TelemetrySetup`, the config data classes,
+the gRPC interceptors) are the natural first things to migrate into Dagger modules.
+
+## Work Needed
+
+1. Research `dagger-grpc` and assess compatibility with the Armeria + grpc-java stack in use
+   (`armeria 1.26.4`, `grpc-java 1.71.0`, `grpc-kotlin 1.5.0`).
+2. Configure Bazel kapt for `rules_kotlin 2.1.9` — the Dagger compiler runs as a kapt
+   annotation processor. Verify the `plugins` / `kt_compiler_plugin` wiring works with the
+   current build graph.
+3. Define `@Component` interfaces for the service and client binaries.
+4. Define `@Module` classes for: config, telemetry (OTel SDK instances, interceptors),
+   server (Armeria `Server`, `GrpcService`, `BalanceServiceEndpoint`), client (`ManagedChannel`,
+   coroutine stub).
+5. Annotate injectable classes with `@Inject` constructors (starting with
+   `BalanceServiceEndpoint`).
+6. Define test modules (e.g. a `FakeTelemetryModule`) that swap in OTel no-op SDK instances
+   for unit tests that don't need a live OTLP exporter.
+
+## References
+
+- OTel plan: `thoughts/shared/plans/2026-03-07-kotlin-otel-instrumentation.md`
+- dagger-grpc: https://github.com/google/dagger (see grpc extension docs)
+- Dagger 2: https://dagger.dev


### PR DESCRIPTION
Introduces Hoplite-based configuration loading and a `ConfigCommand<C>` base class that binds Clikt options directly onto config data classes.

- Add `hoplite-core` and `hoplite-yaml` Maven deps
- `Config.kt`: `ServiceAppConfig`, `ClientAppConfig`, `ServiceConfig`, `ClientConfig`, `TelemetryConfig` data classes with sensible defaults
- `ConfigLoader.kt`: `loadConfig()` loads YAML from classpath resource
- `ConfigCommand.kt`: `ConfigCommand<C>` base class with `applyTo {}` option binding and `resolveConfig()` / `assertAllOptionsAreBound()`
- Wire config into server and client binaries; add YAML resources under `//kotlin/src/main/resources`