### PR TITLE
Fix: service binds to configured host, not 0.0.0.0

### DIFF
--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/service.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/service.kt
@@ -18,6 +18,7 @@ import io.grpc.ServerInterceptor
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.instrumentation.armeria.v1_3.ArmeriaServerTelemetry
 import io.opentelemetry.sdk.resources.Resource
+import java.net.InetSocketAddress
 
 private val log = KotlinLogging.logger {}
 
@@ -62,7 +63,7 @@ class BracketsService : ConfigCommand<ServiceAppConfig>("brackets_service") {
     try {
       val server =
         Server.builder()
-          .http(config.service.port)
+          .http(InetSocketAddress(config.service.host, config.service.port))
           .decorator(ArmeriaServerTelemetry.create(otel).newDecorator())
           .service(wrapService(BalanceServiceEndpoint()))
           .serverListener(


### PR DESCRIPTION
The `--host` CLI flag and `service.host` config value were silently ignored — `Server.builder().http(port)` always bound to all interfaces.

**Fix:** pass `InetSocketAddress(host, port)` instead.

```kotlin
// Before
.http(config.service.port)

// After
.http(InetSocketAddress(config.service.host, config.service.port))
```

Fixes #18