### PR TITLE
docs: track thoughts/, plans, tickets, and PR workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ MODULE.bazel.lock
 
 target
 out
+
+# Override global gitignore exclusions for project-tracked directories
+!thoughts
+!AGENT.md

--- a/thoughts/shared/plans/2026-03-22-kotlin-dagger-grpc-di.md
+++ b/thoughts/shared/plans/2026-03-22-kotlin-dagger-grpc-di.md
@@ -1,0 +1,543 @@
+# Kotlin Dagger DI via dagger-grpc Implementation Plan
+
+## Overview
+
+Introduce Dagger 2 as the compile-time DI framework for the Kotlin `brackets` service, using
+`geekinasuit/dagger-grpc` for the Armeria/gRPC binding. This replaces the manual object
+construction in `BracketsService.run()` with a generated component graph, adds injectable
+interceptors via Dagger multibindings, and annotates `BalanceServiceEndpoint` with
+`@Inject` constructor + `@GrpcServiceHandler` so the KSP processor generates its adapter class.
+
+Client DI is explicitly deferred (see ticket `kotlin-dagger-client-di.md`).
+
+## Current State Analysis
+
+- **`BracketsService.run()`** manually constructs: `Resource`, `BalanceServiceEndpoint`, Armeria `Server`. It also calls `initTelemetry(resource, config.telemetry)` for its side effect of registering the OTel SDK as the `GlobalOpenTelemetry` singleton — the returned `GrpcOpenTelemetry` is discarded (the service never captures it, unlike the client).
+- **`BalanceServiceEndpoint`** has a `// TODO: make @Inject constructor params` comment; uses `GlobalOpenTelemetry.get()` for both `Tracer` and `Meter`.
+- **`BalanceServiceEndpoint`** already implements `BalanceBracketsGrpc.AsyncService` and `BindableService` directly — the `BindableService` impl will move to the generated adapter.
+- **Interceptors**: `wrapService()` takes `vararg interceptors` but none are wired in; the hook has always been empty.
+- **No kapt/KSP** is configured in the build today.
+
+## Desired End State
+
+The Kotlin service binary is assembled by a Dagger `ApplicationGraph` component. All construction
+is in `@Module` objects. `BracketsService.run()` only: resolves CLI config, constructs the graph
+via `ApplicationGraph.builder().config(config).build()`, then calls `graph.server().start().join()`.
+
+`BalanceServiceEndpoint` has an `@Inject` constructor taking `OpenTelemetry`. A KSP-generated
+`BalanceServiceEndpointAdapter` wraps it and is contributed to `Set<BindableService>` via
+`GrpcHandlersModule`. Interceptors are declared per-module via `@IntoSet` and passed through
+`wrapService()` at `ServerModule`.
+
+The `GrpcHandlersModule` and `GrpcCallScopeGraph` are hand-written in this plan (both are marked
+`@Generated("to be generated")` mirroring the convention in the dagger-grpc library). When
+`dagger-grpc`'s `module_generator.kt` is completed, those files will be replaced by generated output.
+
+### Key Discoveries
+
+- `geekinasuit/dagger-grpc` is Armeria-native — `wrapService()` returns `GrpcService` (armeria-grpc). No grpc-netty on the server side. Perfect match for this project.
+- KSP (not kapt) — dagger-grpc uses `DaggerGrpcSymbolProcessor` via `SymbolProcessorProvider`. The Dagger compiler also runs as a KSP plugin (not a separate annotation processor).
+- `@GrpcServiceHandler(BalanceBracketsGrpc::class)` validates that `BalanceBracketsGrpc` has an inner `AsyncService` interface — it does.
+- `GrpcCallScopeGraph.Supplier` is a `@Subcomponent.Factory` interface; `ApplicationGraph` extends it, making the root component self-sufficient as the call-scope factory. `ApplicationGraphModule` provides `applicationGraph: ApplicationGraph` back as `GrpcCallScopeGraph.Supplier` to satisfy that binding.
+- `Set<@JvmSuppressWildcards BindableService>` — the `@JvmSuppressWildcards` annotation is required on Kotlin multibinding injection points.
+- dagger-grpc is not on Maven Central; it must be referenced via `git_override` in `MODULE.bazel`.
+
+## What We're NOT Doing
+
+- Client DI (separate ticket)
+- Per-call telemetry injection (OTel bindings live at `@ApplicationScope`; the `GrpcCallContext` pair binding is added for completeness but not used in this endpoint)
+- Implementing `module_generator.kt` in dagger-grpc (separate effort in that project)
+- Removing `GlobalOpenTelemetry` registration — `initTelemetry()` still sets it as a side effect; `TelemetryModule` captures the return value and exposes `OpenTelemetry` from `GlobalOpenTelemetry.get()` after init
+- Kubernetes / Docker changes (separate ticket)
+
+---
+
+## Implementation Approach
+
+Five phases, each independently buildable and testable:
+
+1. **Build wiring** — add dagger-grpc dep, Maven artifacts, KSP plugins to BUILD files
+2. **Annotate `BalanceServiceEndpoint`** — `@GrpcServiceHandler`, `@GrpcCallScope`, `@Inject constructor`
+3. **Write Dagger modules** — Config, Telemetry, Server, GrpcCallScope, GrpcHandlers, Interceptors
+4. **Write `ApplicationGraph` component; migrate `run()`** — remove manual construction from `BracketsService.run()`
+5. **Test module** — `FakeTelemetryModule` for unit tests
+
+---
+
+## Phase 1: Build Wiring
+
+### Overview
+
+Add `dagger-grpc` as a bzlmod dependency, add Dagger + javax.inject Maven artifacts, register
+the two KSP plugins (dagger-grpc adapter generator + Dagger component generator) in the service
+library's `BUILD.bazel`.
+
+### Changes Required
+
+#### 1. `MODULE.bazel` — add dagger-grpc bzlmod dep
+
+Add after the `grpc_kotlin` dep:
+
+```starlark
+bazel_dep(name = "dagger-grpc", version = "0.1")
+git_override(
+    module_name = "dagger-grpc",
+    remote = "https://github.com/geekinasuit/dagger-grpc.git",
+    commit = "<pin to HEAD commit at time of implementation>",
+)
+```
+
+#### 2. `MODULE.bazel` — add Maven artifacts
+
+In `maven.install(artifacts = [...])`, add:
+
+```starlark
+"com.google.dagger:dagger:2.55",
+"javax.inject:javax.inject:1",
+```
+
+Note: `dagger-compiler` runs as a KSP plugin sourced from `@dagger-grpc//third_party/dagger:dagger-compiler` — no Maven dep needed for the compiler.
+
+#### 3. `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BUILD.bazel`
+
+Add `plugins` and additional `deps` to `service_lib`:
+
+```starlark
+kt_jvm_library(
+    name = "service_lib",
+    srcs = glob(["*.kt", "dagger/*.kt"]),
+    plugins = [
+        "@dagger-grpc//io_grpc/compiler/ksp:plugin",       # generates *Adapter.kt
+        "@dagger-grpc//third_party/dagger:dagger-compiler", # generates DaggerApplicationGraph
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        # existing deps ...
+        "@dagger-grpc//api",
+        "@dagger-grpc//util/armeria",
+        "@maven//:com_google_dagger_dagger",
+        "@maven//:javax_inject_javax_inject",
+    ],
+    # runtime_deps unchanged
+)
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `bazel build //kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service:service_lib` completes without error
+- [ ] The KSP output directory (under `bazel-bin`) contains `BalanceServiceEndpointAdapter.kt` once Phase 2 is done
+- [ ] `bazel query @dagger-grpc//...` lists targets (confirms the override resolves)
+
+#### Manual Verification
+- [ ] No unexpected transitive dependency conflicts in `bazel deps //kotlin/...`
+
+---
+
+## Phase 2: Annotate `BalanceServiceEndpoint`
+
+### Overview
+
+Add `@GrpcServiceHandler`, `@GrpcCallScope`, and `@Inject constructor(otel: OpenTelemetry)` to
+`BalanceServiceEndpoint`. Remove the `BindableService` implementation (the generated adapter
+provides `bindService()`). Remove the `GlobalOpenTelemetry.get()` calls; initialize `tracer`
+and `meter` from the injected `otel` instance instead.
+
+### Changes Required
+
+**File**: `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BalanceServiceEndpoint.kt`
+
+Remove:
+- `import io.grpc.BindableService`
+- `import io.grpc.ServerServiceDefinition`
+- `import io.opentelemetry.api.GlobalOpenTelemetry`
+- `BindableService` from the implements clause
+- `override fun bindService(): ServerServiceDefinition = BalanceBracketsGrpc.bindService(this)`
+- The two `GlobalOpenTelemetry.get()` calls and the `// TODO` comment
+
+Add:
+- `import com.geekinasuit.daggergrpc.api.GrpcCallScope`
+- `import com.geekinasuit.daggergrpc.api.GrpcServiceHandler`
+- `import io.opentelemetry.api.OpenTelemetry`
+- `import javax.inject.Inject`
+
+The class declaration becomes:
+
+```kotlin
+@GrpcServiceHandler(BalanceBracketsGrpc::class)
+@GrpcCallScope
+class BalanceServiceEndpoint @Inject constructor(otel: OpenTelemetry) :
+    BalanceBracketsGrpc.AsyncService {
+
+  private val tracer: Tracer = otel.getTracer("brackets-service")
+  private val meter = otel.getMeter("brackets-service")
+  private val requestCounter: LongCounter =
+    meter.counter("brackets.server.request.count") { setDescription("Number of bracket balance requests") }
+  private val latencyHistogram: LongHistogram =
+    meter.longHistogram("brackets.server.request.duration.ms") { setDescription("Request duration in milliseconds") }
+
+  // balance() override unchanged
+}
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `bazel build //kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service:service_lib` passes
+- [ ] KSP output contains `BalanceServiceEndpointAdapter.kt` with a `() -> BalanceBracketsGrpc.AsyncService` constructor
+- [ ] `BalanceServiceEndpointAdapter.bindService()` delegates to `BalanceBracketsGrpc.bindService(this)` in generated output
+
+---
+
+## Phase 3: Write Dagger Modules
+
+### Overview
+
+Create a `dagger/` subpackage under the service package containing the component infrastructure.
+All files in this phase are hand-written; `GrpcHandlersModule` and `GrpcCallScopeGraph` are
+annotated `@Generated("to be generated by dagger-grpc module_generator")` to signal their
+intended future status.
+
+**Package**: `com.geekinasuit.polyglot.brackets.service.dagger`
+**Directory**: `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/`
+
+### Changes Required
+
+#### 1. `GrpcCallScopeGraph.kt`
+
+```kotlin
+package com.geekinasuit.polyglot.brackets.service.dagger
+
+import com.geekinasuit.daggergrpc.api.GrpcCallScope
+import com.geekinasuit.polyglot.brackets.service.BalanceServiceEndpoint
+import dagger.Subcomponent
+import javax.annotation.Generated
+
+/** Per-call subcomponent. Hand-written; intended to be generated by dagger-grpc module_generator. */
+@Generated("to be generated by dagger-grpc module_generator")
+@GrpcCallScope
+@Subcomponent(modules = [GrpcCallScopeGraphModule::class])
+interface GrpcCallScopeGraph {
+  fun balance(): BalanceServiceEndpoint
+
+  @Subcomponent.Factory
+  interface Supplier {
+    fun callScope(): GrpcCallScopeGraph
+  }
+}
+```
+
+#### 2. `GrpcCallScopeGraphModule.kt`
+
+```kotlin
+package com.geekinasuit.polyglot.brackets.service.dagger
+
+import com.geekinasuit.daggergrpc.api.GrpcCallContext
+import dagger.Module
+
+@Module(includes = [GrpcCallContext.Module::class])
+object GrpcCallScopeGraphModule
+```
+
+#### 3. `GrpcHandlersModule.kt`
+
+```kotlin
+package com.geekinasuit.polyglot.brackets.service.dagger
+
+import com.geekinasuit.polyglot.brackets.service.BalanceServiceEndpointAdapter
+import dagger.Module
+import dagger.Provides
+import dagger.multibindings.IntoSet
+import io.grpc.BindableService
+import javax.annotation.Generated
+
+/** Contributes gRPC service adapters to the Set<BindableService> multibinding.
+ *  Hand-written; intended to be generated by dagger-grpc module_generator. */
+@Generated("to be generated by dagger-grpc module_generator")
+@Module
+object GrpcHandlersModule {
+  @Provides @IntoSet
+  fun balanceHandler(supplier: GrpcCallScopeGraph.Supplier): BindableService =
+    BalanceServiceEndpointAdapter { supplier.callScope().balance() }
+}
+```
+
+#### 4. `InterceptorsModule.kt`
+
+```kotlin
+package com.geekinasuit.polyglot.brackets.service.dagger
+
+import com.geekinasuit.daggergrpc.api.GrpcCallContext
+import dagger.Module
+import dagger.Provides
+import dagger.multibindings.IntoSet
+import io.grpc.ServerInterceptor
+
+/** Declares server-level gRPC interceptors. Add @Provides @IntoSet methods here for each
+ *  interceptor. The Set<ServerInterceptor> is consumed by ServerModule.server(). */
+@Module
+object InterceptorsModule {
+  @Provides @IntoSet
+  fun callContextInterceptor(): ServerInterceptor = GrpcCallContext.Interceptor()
+}
+```
+
+#### 5. `TelemetryModule.kt`
+
+```kotlin
+package com.geekinasuit.polyglot.brackets.service.dagger
+
+import com.geekinasuit.polyglot.brackets.config.ServiceAppConfig
+import com.geekinasuit.polyglot.brackets.telemetry.initTelemetry
+import com.geekinasuit.polyglot.brackets.telemetry.merging
+import com.geekinasuit.daggergrpc.api.ApplicationScope
+import dagger.Module
+import dagger.Provides
+import io.grpc.opentelemetry.GrpcOpenTelemetry
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.sdk.resources.Resource
+
+@Module
+object TelemetryModule {
+  @Provides @ApplicationScope
+  fun grpcOpenTelemetry(config: ServiceAppConfig): GrpcOpenTelemetry {
+    val resource = Resource.getDefault().merging {
+      put("service.name", "brackets-service")
+      put("deployment.environment", config.service.environment)
+      put("service.instance.id", config.service.instanceId)
+    }
+    return initTelemetry(resource, config.telemetry)
+  }
+
+  /**
+   * initTelemetry() registers the SDK as the global OpenTelemetry instance as a side effect.
+   * This binding depends on grpcOpenTelemetry() to guarantee init has run before the global
+   * is read.
+   */
+  @Provides @ApplicationScope
+  @Suppress("UNUSED_PARAMETER")
+  fun openTelemetry(grpcOtel: GrpcOpenTelemetry): OpenTelemetry = GlobalOpenTelemetry.get()
+}
+```
+
+#### 6. `ServerModule.kt`
+
+```kotlin
+package com.geekinasuit.polyglot.brackets.service.dagger
+
+import com.geekinasuit.daggergrpc.api.ApplicationScope
+import com.geekinasuit.daggergrpc.armeria.wrapService
+import com.geekinasuit.polyglot.brackets.config.ServiceAppConfig
+import dagger.Module
+import dagger.Provides
+import io.grpc.BindableService
+import io.grpc.ServerInterceptor
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.instrumentation.armeria.v1_3.ArmeriaServerTelemetry
+import com.linecorp.armeria.server.Server
+import java.net.InetSocketAddress
+
+@Module
+object ServerModule {
+  @Provides @ApplicationScope
+  fun server(
+    services: Set<@JvmSuppressWildcards BindableService>,
+    interceptors: Set<@JvmSuppressWildcards ServerInterceptor>,
+    otel: OpenTelemetry,
+    config: ServiceAppConfig,
+  ): Server = Server.builder()
+    .http(InetSocketAddress(config.service.host, config.service.port))
+    .decorator(ArmeriaServerTelemetry.create(otel).newDecorator())
+    .apply { services.forEach { service(wrapService(it, *interceptors.toTypedArray())) } }
+    .build()
+}
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `bazel build //kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service:service_lib` passes with all module files added
+- [ ] No Dagger binding errors in the build output (Dagger reports missing bindings at compile time)
+
+---
+
+## Phase 4: Write `ApplicationGraph`; Migrate `BracketsService.run()`
+
+### Overview
+
+Create the root Dagger `@Component`. Migrate `BracketsService.run()` to build the graph and
+call `graph.server().start().join()` — all construction leaves `run()`.
+
+### Changes Required
+
+#### 1. `dagger/ApplicationGraph.kt`
+
+```kotlin
+package com.geekinasuit.polyglot.brackets.service.dagger
+
+import com.geekinasuit.daggergrpc.api.ApplicationScope
+import com.geekinasuit.polyglot.brackets.config.ServiceAppConfig
+import com.linecorp.armeria.server.Server
+import dagger.BindsInstance
+import dagger.Component
+
+@ApplicationScope
+@Component(
+  modules = [
+    ApplicationGraphModule::class,
+    GrpcHandlersModule::class,
+    InterceptorsModule::class,
+    TelemetryModule::class,
+    ServerModule::class,
+  ],
+  subcomponents = [GrpcCallScopeGraph::class],
+)
+interface ApplicationGraph : GrpcCallScopeGraph.Supplier {
+  fun server(): Server
+
+  @Component.Builder
+  interface Builder {
+    @BindsInstance fun config(config: ServiceAppConfig): Builder
+    fun build(): ApplicationGraph
+  }
+
+  companion object {
+    fun builder(): Builder = DaggerApplicationGraph.builder()
+  }
+}
+```
+
+#### 2. `dagger/ApplicationGraphModule.kt`
+
+```kotlin
+package com.geekinasuit.polyglot.brackets.service.dagger
+
+import dagger.Module
+import dagger.Provides
+
+/** Satisfies the GrpcCallScopeGraph.Supplier binding by providing the ApplicationGraph itself. */
+@Module
+object ApplicationGraphModule {
+  @Provides
+  fun supplier(graph: ApplicationGraph): GrpcCallScopeGraph.Supplier = graph
+}
+```
+
+#### 3. `service/service.kt` — migrate `run()`
+
+Remove all manual construction. The `run()` body becomes:
+
+```kotlin
+override fun run() {
+  assertAllOptionsAreBound()
+  val config = resolveConfig(loadConfig("/service/application.yml"))
+  val graph = ApplicationGraph.builder().config(config).build()
+  val server = graph.server()
+  server.closeOnJvmShutdown()
+  server.start().join()
+}
+```
+
+Remove the following imports from `service.kt` (now handled by modules):
+- `initTelemetry`, `merging`, `span` from telemetry
+- `GlobalOpenTelemetry`, `ArmeriaServerTelemetry`, `Resource`
+- `GrpcService`, `wrapService` (moved to `ServerModule`)
+- `InetSocketAddress`
+- The startup span logic (consider adding to `ServerModule` or removing — see note below)
+
+**Note on startup span**: The current `run()` wraps server startup in a `server.startup` span.
+With DI, the `Server` is already constructed by Dagger before `run()` calls `start()`. Move
+the startup span into `ServerModule.server()` or into a `ServerListenerAdapter` inside
+`ServerModule`. The latter is idiomatic — add a `ServerListenerAdapter` that starts the span
+in `serverStarting` and ends it in `serverStarted`, using a `Tracer` injected into `ServerModule`.
+
+Add `Tracer` to `ServerModule.server(...)` params: `tracer: Tracer`, provided by:
+
+```kotlin
+// In TelemetryModule:
+@Provides @ApplicationScope
+fun tracer(otel: OpenTelemetry): Tracer = otel.getTracer("brackets-service")
+```
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] `bazel build //kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service:service_bin` passes
+- [ ] `bazel run //kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service:service_bin -- --help` prints usage without errors
+- [ ] Existing tests pass: `bazel test //kotlin/src/test/...`
+
+#### Manual Verification
+- [ ] Service starts: `bazel run :service_bin` binds on expected host/port
+- [ ] Client connects and a balance request succeeds end-to-end
+- [ ] Telemetry initializes (logs show "OTel SDK initialized" line)
+
+**Implementation Note**: After automated and manual verification, confirm before proceeding to Phase 5.
+
+---
+
+## Phase 5: Test Module
+
+### Overview
+
+Add a `FakeTelemetryModule` usable in unit tests that don't need a live OTLP exporter.
+It replaces `TelemetryModule` in test components, binding a no-op `OpenTelemetry` instance
+and a no-op `GrpcOpenTelemetry`.
+
+### Changes Required
+
+**File**: `kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/FakeTelemetryModule.kt`
+
+```kotlin
+package com.geekinasuit.polyglot.brackets.service.dagger
+
+import com.geekinasuit.daggergrpc.api.ApplicationScope
+import dagger.Module
+import dagger.Provides
+import io.grpc.opentelemetry.GrpcOpenTelemetry
+import io.opentelemetry.api.OpenTelemetry
+
+@Module
+object FakeTelemetryModule {
+  @Provides @ApplicationScope
+  fun grpcOpenTelemetry(): GrpcOpenTelemetry =
+    GrpcOpenTelemetry.newBuilder().sdk(io.opentelemetry.sdk.OpenTelemetrySdk.builder().build()).build()
+
+  @Provides @ApplicationScope
+  fun openTelemetry(): OpenTelemetry = OpenTelemetry.noop()
+}
+```
+
+Add a `TestApplicationGraph` in the same test directory that uses `FakeTelemetryModule` in place
+of `TelemetryModule`. Wire an `@Component` for it following the same structure as
+`ApplicationGraph`.
+
+### Success Criteria
+
+#### Automated Verification
+- [ ] A test that instantiates `TestApplicationGraph` without a live OTLP endpoint passes
+- [ ] `bazel test //kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/service/...` all green
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+- `FakeTelemetryModule` makes `BalanceServiceEndpoint` testable without OTel infrastructure
+- Dagger binding correctness is verified at compile time (missing bindings = build error)
+
+### Integration Tests
+- Existing client ↔ service integration test covers end-to-end behavior after Phase 4
+
+### Manual Testing Steps
+1. `bazel run //kotlin/.../service:service_bin` — service starts, logs show Dagger-wired startup
+2. `echo "((()))" | bazel run //kotlin/.../client:client_bin` — returns "Brackets are balanced."
+3. `echo "((" | bazel run //kotlin/.../client:client_bin` — returns "Brackets are NOT balanced"
+
+## References
+
+- Ticket: `thoughts/shared/tickets/kotlin-dagger-grpc-di.md`
+- Library: `https://github.com/geekinasuit/dagger-grpc`
+- Library exemplar: `examples/io_grpc/bazel_build_kt/service/armeria/`
+- Client DI ticket: `thoughts/shared/tickets/kotlin-dagger-client-di.md`
+- OTel plan: `thoughts/shared/plans/2026-03-07-kotlin-otel-instrumentation.md`

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -20,11 +20,15 @@ Ticket files are the source of truth. GitHub Issues are a thin, work-time-only l
 
 | File | Priority | Area | Summary |
 |---|---|---|---|
+| `kotlin-docker-deployment.md` | medium | kotlin, docker, deployment | Docker container build for Kotlin service; staging + production profiles |
 | `github-action-ticket-close-sync.md` | medium | automation, github, tickets | GitHub Action safety net: sync ticket state when issue is closed without a PR ticket update |
 | `grpc-kotlin-bzlmod-migration.md` | low | kotlin, bazel | Migrate to bzlmod-native `grpc_kotlin` when upstream supports it |
 | `go-grpc-library-wrong-proto-target.md` | low | golang, bazel | `go_grpc_library` wraps wrong proto (`//protobuf` → should be `//protobuf:balance_rpc`) |
 | `python-proto-integration-incomplete.md` | low | python, protobuf | Proto import disabled; `foo()` returns `None` |
 | `kotlin-grpc-interceptors-not-implemented.md` | low | kotlin, grpc | `wrapService()` interceptor hook exists but no interceptors implemented |
+| `kotlin-dagger-grpc-di.md` | low | kotlin, grpc, di | Introduce Dagger 2 DI for the Kotlin service via dagger-grpc; plan: `2026-03-22-kotlin-dagger-grpc-di.md` |
+| `kotlin-dagger-client-di.md` | low | kotlin, grpc, di | Dagger DI for the gRPC client binary; prereq: server DI plan |
+| `cross-language-e2e-matrix.md` | low | testing, ci, grpc, multi-language | Matrix test for every (client lang) × (server lang) combination; prereq: all gRPC client+server tickets |
 | `go-grpc-client-server.md` | medium | golang, grpc | Implement gRPC service and client; prereq: proto target fix; model after Kotlin |
 | `java-grpc-client-server.md` | medium | java, grpc | Implement gRPC service and client; model after Kotlin |
 | `python-grpc-client-server.md` | medium | python, grpc | Implement gRPC service and client; prereq: proto fix; model after Kotlin |

--- a/thoughts/shared/tickets/kotlin-dagger-client-di.md
+++ b/thoughts/shared/tickets/kotlin-dagger-client-di.md
@@ -1,0 +1,37 @@
+---
+date: 2026-03-22
+status: open
+priority: low
+area: kotlin, grpc, di
+---
+
+# Kotlin: Dagger DI for the gRPC client
+
+## Summary
+
+The Kotlin gRPC client (`BracketsClient`) currently wires all objects manually in `run()`:
+config, telemetry (`initTelemetry`), `ManagedChannel`, `BalanceBracketsCoroutineStub`. Introduce
+Dagger 2 DI for the client to mirror what is done for the service in ticket
+`kotlin-dagger-grpc-di.md`.
+
+## Context
+
+Deferred from the server DI plan (`thoughts/shared/plans/2026-03-22-kotlin-dagger-grpc-di.md`)
+to keep that plan focused. The client has no call-scoped subcomponent need — it is simpler than
+the service. The server DI plan should be completed and merged before this is started.
+
+## Work Needed
+
+1. Define a `ClientApplicationGraph` `@Component` for the client binary.
+2. Write `ClientConfigModule` — `@BindsInstance ClientAppConfig` (same CLI-first pattern as server; client uses `ClientAppConfig` with `client: ClientConfig`, not `ServiceAppConfig`).
+3. Write `ClientTelemetryModule` — wraps `initTelemetry()` for the client resource.
+4. Write `ChannelModule` — provides `ManagedChannel` (host/port from config, configured with `grpcOtel`).
+5. Write `StubModule` — provides `BalanceBracketsCoroutineStub` from the channel.
+6. Migrate `BracketsClient.run()` to build the graph and call through it.
+7. Add `FakeClientTelemetryModule` for unit tests.
+
+## References
+
+- Server DI plan: `thoughts/shared/plans/2026-03-22-kotlin-dagger-grpc-di.md`
+- Server DI ticket: `thoughts/shared/tickets/kotlin-dagger-grpc-di.md`
+- Dagger docs: https://dagger.dev

--- a/thoughts/shared/tickets/kotlin-docker-deployment.md
+++ b/thoughts/shared/tickets/kotlin-docker-deployment.md
@@ -1,0 +1,39 @@
+---
+date: 2026-03-22
+status: open
+priority: medium
+area: kotlin, docker, deployment
+---
+
+# Feature: Docker container build for the Kotlin service
+
+## Summary
+
+Package the Kotlin gRPC service as a Docker image suitable for staging and production deployment. Initial scope is the Kotlin service only; other language variants can follow once the pattern is established.
+
+## Current State
+
+- Kotlin service binary builds via Bazel (`java_binary` + `runtime_deps`)
+- No container image build target exists
+- No deployment configuration exists (compose, Helm, etc.)
+
+## Goals
+
+- Bazel `container_image` (or equivalent) target that produces a Docker image for the Kotlin service binary
+- Image should be minimal (distroless or equivalent JVM base)
+- Config via environment variables consistent with the existing Hoplite config system (env vars already supported via `DEPLOYMENT_ENV`, `POD_NAME`, `OTLP_ENDPOINT`, etc.)
+- Separate staging and production profiles (e.g. via base image tag or Bazel config flag)
+- Image should be pushable to a registry (registry target TBD)
+
+## Out of Scope (for now)
+
+- Client container (service is the deployment unit)
+- Other language variants
+- Kubernetes manifests / Helm chart (separate ticket if needed)
+
+## References
+
+- `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/` — service binary
+- `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config/Config.kt` — config data classes and env var resolution
+- `kotlin/src/main/resources/` — runtime YAML configs (will need to be embedded or mounted)
+- `MODULE.bazel` — dependency management; container rules to be added here

--- a/thoughts/shared/workflows/pr-review-cycle.md
+++ b/thoughts/shared/workflows/pr-review-cycle.md
@@ -1,0 +1,75 @@
+# PR Review Cycle Workflow
+
+Standard process for taking a local bookmark through review and merge.
+
+## Steps
+
+### 1. Pre-push verification
+- Run full test suite locally: `bazel test //...`
+- Fix any failures before pushing (saves CI resources)
+
+### 2. Push and open PR
+
+> **Note**: This repo runs the `stilliard/github-task-list-completed` GitHub App. It scans
+> **every** body for unchecked checkboxes: the PR description, all PR comments, all review
+> submissions, and all inline review comments. Any unchecked `- [ ]` blocks the check.
+>
+> - Check boxes immediately after verifying (`- [x]`), or mark inapplicable ones with `N/A`,
+>   `POST-MERGE`, or `OPTIONAL` (all caps, inline) to exclude them.
+> - **Never put unchecked checkboxes in review comments** — use prose instead.
+- After `jj commit`, the new commit sits at `@-` (the empty working copy is `@`). Set bookmark to that commit: `jj bookmark set <name> -r @-`
+- Push: `jj git push -b <name>`
+- If no PR exists: `gh pr create --repo geekinasuit/polyglot --title "..." --body "$(cat <<'EOF' ... EOF)"`
+
+### 3. Parallel review agents
+Spin two agents **in parallel** (single message, two Agent tool calls):
+
+**Critique agent** (subagent_type: general-purpose):
+> "You are a code reviewer. Review PR #N at https://github.com/geekinasuit/polyglot/pull/N.
+> Read every changed file. Post inline review comments on GitHub for any real issues (bugs,
+> security, correctness, style violations, misleading names). Do NOT post praise or nitpicks.
+> Use `gh api` to post comments. If there are no issues, output 'LGTM - no issues found' and
+> do nothing."
+
+**Response agent** (subagent_type: general-purpose):
+> "Read PR #N at https://github.com/geekinasuit/polyglot/pull/N. Collect all open review
+> comments (from the critique agent AND any AI/human reviewers). For each comment, either
+> propose a concrete code fix or explain why no change is needed. Apply fixes directly to
+> the files. Do NOT push — report back what was changed and what was left as-is with reasons."
+
+### 4. Evaluate responses
+- If response agent made changes: run `bazel test //...`, then push, then re-run review agents
+- If no changes needed (all LGTM): proceed to merge
+
+### 5. Pause for human input if:
+- Response agent flagged any comment as requiring design/product judgment
+- Tests fail after applying fixes
+- Conflicting review comments
+
+### 6. Resolve all review threads
+
+After replying to every comment, resolve each thread — replies alone do not unblock merge:
+
+```bash
+# Find unresolved thread IDs
+gh api graphql -f query='query($owner:String!,$repo:String!,$pr:Int!){repository(owner:$owner,name:$repo){pullRequest(number:$pr){reviewThreads(first:50){nodes{id isResolved}}}}}' \
+  -f owner=geekinasuit -f repo=polyglot -F pr=<N> \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)|.id'
+
+# Resolve each one
+gh api graphql -f query='mutation($t:ID!){resolveReviewThread(input:{threadId:$t}){thread{isResolved}}}' \
+  -f t=<thread_id>
+```
+
+### 7. Merge
+```
+gh pr merge <N> --repo geekinasuit/polyglot --squash --auto
+```
+Then fetch and update local main:
+```
+jj git fetch
+jj bookmark set main -r main@origin
+```
+
+## Notes
+- One PR at a time: wait for each merge before pushing the next bookmark that depends on it.


### PR DESCRIPTION
## Summary

- Override global gitignore to include `thoughts/` and `AGENTS.md` in repo tracking
- Add Dagger DI implementation plan (`thoughts/shared/plans/2026-03-22-kotlin-dagger-grpc-di.md`)
- Add ticket: `kotlin-docker-deployment.md` — Docker container build for Kotlin service
- Add ticket: `kotlin-dagger-client-di.md` — Dagger DI for the gRPC client (deferred from DI plan)
- Add `thoughts/shared/workflows/pr-review-cycle.md` — documented review-cycle workflow for agent reuse
- Update `TICKETS.md` index with new ticket entries

## Test plan

- [x] No code changes — pure documentation and gitignore update
- [x] Verify `thoughts/` directory is tracked: `jj diff --stat` shows markdown files
- [x] Confirm no source files accidentally included via gitignore override

🤖 Generated with [Claude Code](https://claude.com/claude-code)