### PR TITLE
refactor: apply ktfmt formatting to all Kotlin files; add ktfmt rule to AGENT.md

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -144,6 +144,29 @@ Each language implementation should have equivalent test coverage. The Go and Ja
 
 ## Code Style Principles
 
+### Kotlin Formatting: ktfmt
+
+All Kotlin files in this repository are formatted with **`ktfmt`** (the Google/Meta formatter,
+default style). Before committing any Kotlin file changes:
+
+```
+ktfmt <changed-kotlin-files>
+```
+
+Or to format all Kotlin files at once:
+
+```
+ktfmt $(find kotlin -name "*.kt")
+```
+
+`ktfmt` must be installed (`brew install ktfmt` on macOS). A formatting-only commit is a valid,
+self-contained PR — it carries no behavioral changes and can be reviewed and merged independently.
+
+Do not mix formatting changes with behavioral changes in the same commit. If a file you are
+editing is not yet formatted, format it in a separate preceding commit.
+
+---
+
 ### Idiomatic First, Structurally Familiar Second
 
 Each language implementation should be **idiomatic for that language** — naming, package layout, error handling, and tooling should feel native to a practitioner of that language. Do not mechanically port Kotlin idioms.

--- a/kotlin/src/main/kotlin/bracketskt/brackets.kt
+++ b/kotlin/src/main/kotlin/bracketskt/brackets.kt
@@ -4,12 +4,12 @@ import com.geekinasuit.polyglot.example.protos.Something
 import com.geekinasuit.polyglot.example.protos.something
 import kotlin.collections.ArrayDeque
 
-
-val closedParentheses = mapOf(
-  ')' to '(',
-  '}' to '{',
-  ']' to '[',
-)
+val closedParentheses =
+    mapOf(
+        ')' to '(',
+        '}' to '{',
+        ']' to '[',
+    )
 val openParentheses = closedParentheses.values.toSet()
 
 @Throws()
@@ -24,10 +24,15 @@ public fun balancedBrackets(text: String) {
       }
       in closedParentheses -> {
         val open = closedParentheses[c]
-        val last = stack.removeLastOrNull() ?:
-          throw BracketsNotBalancedException("closing bracket $c with no opening bracket at char ${i+1}")
+        val last =
+            stack.removeLastOrNull()
+                ?: throw BracketsNotBalancedException(
+                    "closing bracket $c with no opening bracket at char ${i+1}"
+                )
         if (last != open)
-          throw BracketsNotBalancedException("closing bracket ] at char ${i+1} mismatched with last opening bracket (")
+            throw BracketsNotBalancedException(
+                "closing bracket ] at char ${i+1} mismatched with last opening bracket ("
+            )
       }
     }
   }

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/client/client.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/client/client.kt
@@ -26,43 +26,56 @@ import kotlinx.coroutines.runBlocking
 private val log = KotlinLogging.logger {}
 
 class BracketsClient : ConfigCommand<ClientAppConfig>("brackets_client") {
-  val host by option("--host").help("Server host (overrides config)")
-    .applyTo { copy(client = client.copy(host = it)) }
-  val port by option("--port").int().help("Server port (overrides config)")
-    .applyTo { copy(client = client.copy(port = it)) }
-  val environment by option("--environment").help("Deployment environment")
-    .applyTo { copy(client = client.copy(environment = it)) }
-  val instanceId by option("--instance-id").help("Unique instance identifier")
-    .applyTo { copy(client = client.copy(instanceId = it)) }
-  val otlpEndpoint by option("--otlp-endpoint")
-    .help("OTLP gRPC endpoint for traces+metrics (e.g. http://localhost:4317)")
-    .applyTo { copy(telemetry = telemetry.copy(otlpEndpoint = it)) }
-  val logEndpoint by option("--log-endpoint")
-    .help("OTLP gRPC endpoint for logs (defaults to --otlp-endpoint)")
-    .applyTo { copy(telemetry = telemetry.copy(logEndpoint = it)) }
+  val host by
+      option("--host").help("Server host (overrides config)").applyTo {
+        copy(client = client.copy(host = it))
+      }
+  val port by
+      option("--port").int().help("Server port (overrides config)").applyTo {
+        copy(client = client.copy(port = it))
+      }
+  val environment by
+      option("--environment").help("Deployment environment").applyTo {
+        copy(client = client.copy(environment = it))
+      }
+  val instanceId by
+      option("--instance-id").help("Unique instance identifier").applyTo {
+        copy(client = client.copy(instanceId = it))
+      }
+  val otlpEndpoint by
+      option("--otlp-endpoint")
+          .help("OTLP gRPC endpoint for traces+metrics (e.g. http://localhost:4317)")
+          .applyTo { copy(telemetry = telemetry.copy(otlpEndpoint = it)) }
+  val logEndpoint by
+      option("--log-endpoint")
+          .help("OTLP gRPC endpoint for logs (defaults to --otlp-endpoint)")
+          .applyTo { copy(telemetry = telemetry.copy(logEndpoint = it)) }
   val text by argument().inputStream()
 
   override fun run(): Unit = runBlocking {
     assertAllOptionsAreBound()
     val config = resolveConfig(loadConfig("/client/application.yml"))
 
-    val resource = Resource.getDefault().merging {
-      put("service.name", "brackets-client")
-      put("deployment.environment", config.client.environment)
-      put("service.instance.id", config.client.instanceId)
-    }
+    val resource =
+        Resource.getDefault().merging {
+          put("service.name", "brackets-client")
+          put("deployment.environment", config.client.environment)
+          put("service.instance.id", config.client.instanceId)
+        }
     val grpcOtel = initTelemetry(resource, config.telemetry)
 
     log.info {
       "brackets client starting: target=${config.client.host}:${config.client.port} " +
-        "environment=${config.client.environment} instanceId=${config.client.instanceId} " +
-        "otlpEndpoint=${config.telemetry.otlpEndpoint ?: "(disabled)"}"
+          "environment=${config.client.environment} instanceId=${config.client.instanceId} " +
+          "otlpEndpoint=${config.telemetry.otlpEndpoint ?: "(disabled)"}"
     }
 
-    val callCounter = GlobalOpenTelemetry.get().getMeter("brackets-client")
-      .counter("brackets.client.call.count") {
-        setDescription("Number of bracket balance calls made by the client")
-      }
+    val callCounter =
+        GlobalOpenTelemetry.get().getMeter("brackets-client").counter(
+            "brackets.client.call.count"
+        ) {
+          setDescription("Number of bracket balance calls made by the client")
+        }
 
     val buffer = text.bufferedReader().use(BufferedReader::readText)
     text.close()
@@ -74,25 +87,26 @@ class BracketsClient : ConfigCommand<ClientAppConfig>("brackets_client") {
     println("========")
 
     val channel =
-      ManagedChannelBuilder.forAddress(config.client.host, config.client.port)
-        .usePlaintext()
-        .also(grpcOtel::configureChannelBuilder)
-        .build()
+        ManagedChannelBuilder.forAddress(config.client.host, config.client.port)
+            .usePlaintext()
+            .also(grpcOtel::configureChannelBuilder)
+            .build()
     val stub = BalanceBracketsGrpcKt.BalanceBracketsCoroutineStub(channel)
     val request = BalanceRequest.newBuilder().setStatement(buffer).build()
 
     val response =
-      try {
-        stub.balance(request)
-      } catch (e: Exception) {
-        callCounter.add(1, attributes { put("result", "connection_error") })
-        System.err.println(
-          "Error connecting to bracket balance service: ${e.cause?.message ?: e.message}"
-        )
-        throw ProgramResult(1)
-      }
+        try {
+          stub.balance(request)
+        } catch (e: Exception) {
+          callCounter.add(1, attributes { put("result", "connection_error") })
+          System.err.println(
+              "Error connecting to bracket balance service: ${e.cause?.message ?: e.message}"
+          )
+          throw ProgramResult(1)
+        }
 
-    val result = if (response.succeeded) if (response.isBalanced) "balanced" else "not_balanced" else "error"
+    val result =
+        if (response.succeeded) if (response.isBalanced) "balanced" else "not_balanced" else "error"
     callCounter.add(1, attributes { put("result", result) })
 
     log.info { "Response: succeeded=${response.succeeded} isBalanced=${response.isBalanced}" }

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config/Config.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config/Config.kt
@@ -2,43 +2,42 @@ package com.geekinasuit.polyglot.brackets.config
 
 /** Top-level config for the service binary. */
 data class ServiceAppConfig(
-  val service: ServiceConfig = ServiceConfig(),
-  val telemetry: TelemetryConfig = TelemetryConfig(),
+    val service: ServiceConfig = ServiceConfig(),
+    val telemetry: TelemetryConfig = TelemetryConfig(),
 )
 
 /** Top-level config for the client binary. */
 data class ClientAppConfig(
-  val client: ClientConfig = ClientConfig(),
-  val telemetry: TelemetryConfig = TelemetryConfig(),
+    val client: ClientConfig = ClientConfig(),
+    val telemetry: TelemetryConfig = TelemetryConfig(),
 )
 
 data class ServiceConfig(
-  val host: String = "localhost",
-  val port: Int = 8888,
-  val environment: String = defaultEnvironment(),
-  val instanceId: String = defaultInstanceId(),
+    val host: String = "localhost",
+    val port: Int = 8888,
+    val environment: String = defaultEnvironment(),
+    val instanceId: String = defaultInstanceId(),
 )
 
 data class ClientConfig(
-  val host: String = "localhost",
-  val port: Int = 8888,
-  val environment: String = defaultEnvironment(),
-  val instanceId: String = defaultInstanceId(),
+    val host: String = "localhost",
+    val port: Int = 8888,
+    val environment: String = defaultEnvironment(),
+    val instanceId: String = defaultInstanceId(),
 )
 
 data class TelemetryConfig(
-  /** OTLP gRPC endpoint for traces and metrics. Null disables OTLP export. */
-  val otlpEndpoint: String? = null,
-  /**
-   * OTLP gRPC endpoint for logs. Null falls back to [otlpEndpoint].
-   * See [effectiveLogEndpoint].
-   */
-  val logEndpoint: String? = null,
-  val metricsExportIntervalSeconds: Long = 60,
-  val tracingEnabled: Boolean = true,
-  val metricsEnabled: Boolean = true,
-  /** Disabled by default — must be explicitly opted in per environment. */
-  val loggingExportEnabled: Boolean = false,
+    /** OTLP gRPC endpoint for traces and metrics. Null disables OTLP export. */
+    val otlpEndpoint: String? = null,
+    /**
+     * OTLP gRPC endpoint for logs. Null falls back to [otlpEndpoint]. See [effectiveLogEndpoint].
+     */
+    val logEndpoint: String? = null,
+    val metricsExportIntervalSeconds: Long = 60,
+    val tracingEnabled: Boolean = true,
+    val metricsEnabled: Boolean = true,
+    /** Disabled by default — must be explicitly opted in per environment. */
+    val loggingExportEnabled: Boolean = false,
 )
 
 /** Resolves the log OTLP endpoint, falling back to the main OTLP endpoint. */
@@ -46,27 +45,28 @@ val TelemetryConfig.effectiveLogEndpoint: String?
   get() = logEndpoint ?: otlpEndpoint
 
 /**
- * Resolves the deployment environment from standard env vars, defaulting to "development".
- * Checks DEPLOYMENT_ENV then ENVIRONMENT.
+ * Resolves the deployment environment from standard env vars, defaulting to "development". Checks
+ * DEPLOYMENT_ENV then ENVIRONMENT.
  */
 fun defaultEnvironment(): String =
-  System.getenv("DEPLOYMENT_ENV") ?: System.getenv("ENVIRONMENT") ?: "development"
+    System.getenv("DEPLOYMENT_ENV") ?: System.getenv("ENVIRONMENT") ?: "development"
 
 /**
  * Resolves a unique per-instance identifier using standard signals (first match wins):
- *  - Kubernetes: $POD_NAME (inject via Downward API)
- *  - Docker:     $HOSTNAME when it looks like a container ID (12–64 hex chars)
- *  - Dev:        "$user@$hostname" — disambiguates concurrent local instances
+ * - Kubernetes: $POD_NAME (inject via Downward API)
+ * - Docker: $HOSTNAME when it looks like a container ID (12–64 hex chars)
+ * - Dev: "$user@$hostname" — disambiguates concurrent local instances
  *
- * TODO: Become an @Inject constructor parameter when the Dagger ticket is implemented.
- * See thoughts/shared/tickets/kotlin-dagger-grpc-di.md
+ * TODO: Become an @Inject constructor parameter when the Dagger ticket is implemented. See
+ *   thoughts/shared/tickets/kotlin-dagger-grpc-di.md
  */
 fun defaultInstanceId(): String {
-  System.getenv("POD_NAME")?.let { return it }
+  System.getenv("POD_NAME")?.let {
+    return it
+  }
   val hostname = System.getenv("HOSTNAME") ?: ""
   if (hostname.matches(Regex("[a-f0-9]{12,64}"))) return hostname
   val user = System.getProperty("user.name") ?: "unknown"
-  val host =
-    runCatching { java.net.InetAddress.getLocalHost().hostName }.getOrDefault("localhost")
+  val host = runCatching { java.net.InetAddress.getLocalHost().hostName }.getOrDefault("localhost")
   return "$user@$host"
 }

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config/ConfigCommand.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config/ConfigCommand.kt
@@ -9,9 +9,9 @@ import kotlin.reflect.KProperty
  * Base class for commands driven by a Hoplite config file with selective CLI overrides.
  *
  * Declare CLI options using [applyTo] to bind each option to a mutation on the config type [C].
- * When the option is provided on the command line, the mutation fires; if absent, the config
- * file value is left unchanged. Call [resolveConfig] inside [run] to obtain the final merged
- * config after all CLI overrides have been applied.
+ * When the option is provided on the command line, the mutation fires; if absent, the config file
+ * value is left unchanged. Call [resolveConfig] inside [run] to obtain the final merged config
+ * after all CLI overrides have been applied.
  *
  * Example:
  * ```kotlin
@@ -26,47 +26,47 @@ import kotlin.reflect.KProperty
  * ```
  *
  * Validation: at startup, [assertAllOptionsAreBound] can be called to confirm every registered
- * Clikt option has a corresponding [applyTo] binding. Any option declared without [applyTo]
- * will be parsed and available, but its value will not be applied to the config automatically.
+ * Clikt option has a corresponding [applyTo] binding. Any option declared without [applyTo] will be
+ * parsed and available, but its value will not be applied to the config automatically.
  */
 abstract class ConfigCommand<C : Any>(name: String) : CliktCommand(name = name) {
   private val mutations = mutableListOf<C.() -> C>()
 
   /**
-   * Binds this option to a config mutation. When the option is provided on the CLI, [mutate]
-   * is invoked on the current config with the parsed value, and the result replaces the config.
-   * When the option is absent, [mutate] is not called and the config is unchanged.
+   * Binds this option to a config mutation. When the option is provided on the CLI, [mutate] is
+   * invoked on the current config with the parsed value, and the result replaces the config. When
+   * the option is absent, [mutate] is not called and the config is unchanged.
    *
    * Returns a [ReadOnlyProperty] delegate; use with `by` as normal.
    */
   fun <T : Any> OptionWithValues<T?, T, T>.applyTo(
-    mutate: C.(T) -> C
+      mutate: C.(T) -> C
   ): MutatingOptionDelegate<T, C> = MutatingOptionDelegate(this, mutations, mutate)
 
   /**
-   * Applies all registered CLI mutations to [base] in declaration order.
-   * Call this inside [run] after option parsing is complete.
+   * Applies all registered CLI mutations to [base] in declaration order. Call this inside [run]
+   * after option parsing is complete.
    */
   protected fun resolveConfig(base: C): C = mutations.fold(base) { cfg, m -> cfg.m() }
 
   /**
-   * Asserts that the number of registered [applyTo] bindings equals the number of non-eager
-   * options registered with Clikt. A mismatch means at least one option was declared without
-   * a corresponding config binding.
+   * Asserts that the number of registered [applyTo] bindings equals the number of non-eager options
+   * registered with Clikt. A mismatch means at least one option was declared without a
+   * corresponding config binding.
    *
    * Call early in [run] when you want startup-time validation.
    */
   protected fun assertAllOptionsAreBound() {
     // Exclude Clikt's built-in eager options (--help, --version, etc.) from the count.
     val userOptionCount =
-      registeredOptions().count { opt ->
-        opt.names.any { it.startsWith("--") } &&
-          opt.names.none { it == "--help" || it == "--version" }
-      }
+        registeredOptions().count { opt ->
+          opt.names.any { it.startsWith("--") } &&
+              opt.names.none { it == "--help" || it == "--version" }
+        }
     check(userOptionCount == mutations.size) {
       "Option/config binding mismatch: $userOptionCount option(s) registered, " +
-        "${mutations.size} applyTo binding(s) found. " +
-        "Every '--' option should use applyTo { } to bind it to the config."
+          "${mutations.size} applyTo binding(s) found. " +
+          "Every '--' option should use applyTo { } to bind it to the config."
     }
   }
 }
@@ -75,22 +75,20 @@ abstract class ConfigCommand<C : Any>(name: String) : CliktCommand(name = name) 
  * A property delegate produced by [ConfigCommand.applyTo].
  *
  * When bound via `by`, it registers the underlying Clikt option with the command (so help text,
- * parsing, and type coercion work as usual) and simultaneously registers a lazy mutation that
- * reads the option's parsed value at [ConfigCommand.resolveConfig] time.
+ * parsing, and type coercion work as usual) and simultaneously registers a lazy mutation that reads
+ * the option's parsed value at [ConfigCommand.resolveConfig] time.
  */
 class MutatingOptionDelegate<T : Any, C : Any>(
-  private val wrapped: OptionWithValues<T?, T, T>,
-  private val mutations: MutableList<C.() -> C>,
-  private val mutate: C.(T) -> C,
+    private val wrapped: OptionWithValues<T?, T, T>,
+    private val mutations: MutableList<C.() -> C>,
+    private val mutate: C.(T) -> C,
 ) {
   operator fun provideDelegate(
-    thisRef: ConfigCommand<C>,
-    prop: KProperty<*>,
+      thisRef: ConfigCommand<C>,
+      prop: KProperty<*>,
   ): ReadOnlyProperty<CliktCommand, T?> {
     val inner = wrapped.provideDelegate(thisRef, prop)
-    mutations.add {
-      inner.getValue(thisRef, prop)?.let { v -> mutate(v) } ?: this
-    }
+    mutations.add { inner.getValue(thisRef, prop)?.let { v -> mutate(v) } ?: this }
     return inner
   }
 }

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config/ConfigLoader.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config/ConfigLoader.kt
@@ -6,25 +6,26 @@ import com.sksamuel.hoplite.addResourceOrFileSource
 
 /**
  * Builds a Hoplite config loader with layered sources (lowest → highest priority):
- *   1. YAML resource file at [resourcePath] (optional; missing file is tolerated)
- *   2. Environment variables
+ * 1. YAML resource file at [resourcePath] (optional; missing file is tolerated)
+ * 2. Environment variables
  *
  * CLI flag overrides are applied by callers after loading via data class copy().
  *
  * Extension seam: insert additional PropertySource implementations into this builder for:
- *   - Secrets manager (e.g., AWS Secrets Manager, HashiCorp Vault)
- *   - Feature flag overrides (e.g., LaunchDarkly)
+ * - Secrets manager (e.g., AWS Secrets Manager, HashiCorp Vault)
+ * - Feature flag overrides (e.g., LaunchDarkly)
+ *
  * Sources added later in the builder chain take higher precedence.
  *
- * Note on env var naming: with useUnderscoresAsSeparator=true, single underscores act as
- * path separators. This works cleanly for single-word nested keys (e.g., SERVICE_HOST →
- * service.host, SERVICE_PORT → service.port). For multi-word camelCase fields, the CLI
- * flags are the reliable override mechanism.
+ * Note on env var naming: with useUnderscoresAsSeparator=true, single underscores act as path
+ * separators. This works cleanly for single-word nested keys (e.g., SERVICE_HOST → service.host,
+ * SERVICE_PORT → service.port). For multi-word camelCase fields, the CLI flags are the reliable
+ * override mechanism.
  */
 fun buildConfigLoader(resourcePath: String): ConfigLoaderBuilder =
-  ConfigLoaderBuilder.default()
-    .addResourceOrFileSource(resourcePath, optional = true)
-    .addEnvironmentSource(useUnderscoresAsSeparator = true, allowUppercaseNames = true)
+    ConfigLoaderBuilder.default()
+        .addResourceOrFileSource(resourcePath, optional = true)
+        .addEnvironmentSource(useUnderscoresAsSeparator = true, allowUppercaseNames = true)
 
 inline fun <reified T : Any> loadConfig(resourcePath: String): T =
-  buildConfigLoader(resourcePath).build().loadConfigOrThrow()
+    buildConfigLoader(resourcePath).build().loadConfigOrThrow()

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BalanceServiceEndpoint.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BalanceServiceEndpoint.kt
@@ -26,37 +26,42 @@ class BalanceServiceEndpoint : BalanceBracketsGrpc.AsyncService, BindableService
   private val tracer: Tracer = GlobalOpenTelemetry.get().getTracer("brackets-service")
   private val meter = GlobalOpenTelemetry.get().getMeter("brackets-service")
   private val requestCounter: LongCounter =
-    meter.counter("brackets.server.request.count") { setDescription("Number of bracket balance requests") }
+      meter.counter("brackets.server.request.count") {
+        setDescription("Number of bracket balance requests")
+      }
   private val latencyHistogram: LongHistogram =
-    meter.longHistogram("brackets.server.request.duration.ms") { setDescription("Request duration in milliseconds") }
+      meter.longHistogram("brackets.server.request.duration.ms") {
+        setDescription("Request duration in milliseconds")
+      }
 
   override fun balance(request: BalanceRequest, responseObserver: StreamObserver<BalanceResponse>) {
     val startMs = System.currentTimeMillis()
-    val span = tracer.span("balance-brackets") {
-      setAttribute("statement.length", request.statement.length.toLong())
-      setAttribute("statement.text", request.statement)
-    }
+    val span =
+        tracer.span("balance-brackets") {
+          setAttribute("statement.length", request.statement.length.toLong())
+          setAttribute("statement.text", request.statement)
+        }
     var result = "error"
     try {
       span.makeCurrent().use {
         val responseBuilder = BalanceResponse.newBuilder()
         result =
-          try {
-            log.info { "Balancing brackets: length=${request.statement.length}" }
-            balancedBrackets(request.statement)
-            log.info { "Brackets are balanced." }
-            responseBuilder.setIsBalanced(true).setSucceeded(true)
-            "balanced"
-          } catch (e: BracketsNotBalancedException) {
-            log.info { "Brackets not balanced: ${e.message}" }
-            responseBuilder.setIsBalanced(false).setSucceeded(true).setError(e.message)
-            "not_balanced"
-          } catch (e: Exception) {
-            log.info { "Error balancing brackets: ${e.message}" }
-            responseBuilder.setSucceeded(false).setError(e.message)
-            span.setStatus(StatusCode.ERROR, e.message ?: "unknown error")
-            "error"
-          }
+            try {
+              log.info { "Balancing brackets: length=${request.statement.length}" }
+              balancedBrackets(request.statement)
+              log.info { "Brackets are balanced." }
+              responseBuilder.setIsBalanced(true).setSucceeded(true)
+              "balanced"
+            } catch (e: BracketsNotBalancedException) {
+              log.info { "Brackets not balanced: ${e.message}" }
+              responseBuilder.setIsBalanced(false).setSucceeded(true).setError(e.message)
+              "not_balanced"
+            } catch (e: Exception) {
+              log.info { "Error balancing brackets: ${e.message}" }
+              responseBuilder.setSucceeded(false).setError(e.message)
+              span.setStatus(StatusCode.ERROR, e.message ?: "unknown error")
+              "error"
+            }
         span.setAttribute("result", result)
         responseObserver.onNext(responseBuilder.build())
         responseObserver.onCompleted()

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/service.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/service.kt
@@ -23,36 +23,47 @@ import java.net.InetSocketAddress
 private val log = KotlinLogging.logger {}
 
 class BracketsService : ConfigCommand<ServiceAppConfig>("brackets_service") {
-  val host by option("--host").help("Bind host (overrides config)")
-    .applyTo { copy(service = service.copy(host = it)) }
-  val port by option("--port").int().help("Bind port (overrides config)")
-    .applyTo { copy(service = service.copy(port = it)) }
-  val environment by option("--environment").help("Deployment environment")
-    .applyTo { copy(service = service.copy(environment = it)) }
-  val instanceId by option("--instance-id").help("Unique instance identifier")
-    .applyTo { copy(service = service.copy(instanceId = it)) }
-  val otlpEndpoint by option("--otlp-endpoint")
-    .help("OTLP gRPC endpoint for traces+metrics (e.g. http://localhost:4317)")
-    .applyTo { copy(telemetry = telemetry.copy(otlpEndpoint = it)) }
-  val logEndpoint by option("--log-endpoint")
-    .help("OTLP gRPC endpoint for logs (defaults to --otlp-endpoint)")
-    .applyTo { copy(telemetry = telemetry.copy(logEndpoint = it)) }
+  val host by
+      option("--host").help("Bind host (overrides config)").applyTo {
+        copy(service = service.copy(host = it))
+      }
+  val port by
+      option("--port").int().help("Bind port (overrides config)").applyTo {
+        copy(service = service.copy(port = it))
+      }
+  val environment by
+      option("--environment").help("Deployment environment").applyTo {
+        copy(service = service.copy(environment = it))
+      }
+  val instanceId by
+      option("--instance-id").help("Unique instance identifier").applyTo {
+        copy(service = service.copy(instanceId = it))
+      }
+  val otlpEndpoint by
+      option("--otlp-endpoint")
+          .help("OTLP gRPC endpoint for traces+metrics (e.g. http://localhost:4317)")
+          .applyTo { copy(telemetry = telemetry.copy(otlpEndpoint = it)) }
+  val logEndpoint by
+      option("--log-endpoint")
+          .help("OTLP gRPC endpoint for logs (defaults to --otlp-endpoint)")
+          .applyTo { copy(telemetry = telemetry.copy(logEndpoint = it)) }
 
   override fun run() {
     assertAllOptionsAreBound()
     val config = resolveConfig(loadConfig("/service/application.yml"))
 
-    val resource = Resource.getDefault().merging {
-      put("service.name", "brackets-service")
-      put("deployment.environment", config.service.environment)
-      put("service.instance.id", config.service.instanceId)
-    }
+    val resource =
+        Resource.getDefault().merging {
+          put("service.name", "brackets-service")
+          put("deployment.environment", config.service.environment)
+          put("service.instance.id", config.service.instanceId)
+        }
     initTelemetry(resource, config.telemetry)
 
     log.info {
       "brackets service starting: host=${config.service.host} port=${config.service.port} " +
-        "environment=${config.service.environment} instanceId=${config.service.instanceId} " +
-        "otlpEndpoint=${config.telemetry.otlpEndpoint ?: "(disabled)"}"
+          "environment=${config.service.environment} instanceId=${config.service.instanceId} " +
+          "otlpEndpoint=${config.telemetry.otlpEndpoint ?: "(disabled)"}"
     }
 
     val otel = GlobalOpenTelemetry.get()
@@ -62,28 +73,28 @@ class BracketsService : ConfigCommand<ServiceAppConfig>("brackets_service") {
 
     try {
       val server =
-        Server.builder()
-          .http(InetSocketAddress(config.service.host, config.service.port))
-          .decorator(ArmeriaServerTelemetry.create(otel).newDecorator())
-          .service(wrapService(BalanceServiceEndpoint()))
-          .serverListener(
-            object : com.linecorp.armeria.server.ServerListenerAdapter() {
-              override fun serverStarted(server: Server) {
-                log.info { "Server started: activePorts=${server.activePorts()}" }
-                startupScope.close()
-                startupSpan.end()
-              }
+          Server.builder()
+              .http(InetSocketAddress(config.service.host, config.service.port))
+              .decorator(ArmeriaServerTelemetry.create(otel).newDecorator())
+              .service(wrapService(BalanceServiceEndpoint()))
+              .serverListener(
+                  object : com.linecorp.armeria.server.ServerListenerAdapter() {
+                    override fun serverStarted(server: Server) {
+                      log.info { "Server started: activePorts=${server.activePorts()}" }
+                      startupScope.close()
+                      startupSpan.end()
+                    }
 
-              override fun serverStopping(server: Server) {
-                log.info { "Server stopping: graceful drain started" }
-              }
+                    override fun serverStopping(server: Server) {
+                      log.info { "Server stopping: graceful drain started" }
+                    }
 
-              override fun serverStopped(server: Server) {
-                log.info { "Server stopped." }
-              }
-            }
-          )
-          .build()
+                    override fun serverStopped(server: Server) {
+                      log.info { "Server stopped." }
+                    }
+                  }
+              )
+              .build()
       server.closeOnJvmShutdown()
       server.start().join()
     } catch (e: Exception) {
@@ -97,8 +108,8 @@ class BracketsService : ConfigCommand<ServiceAppConfig>("brackets_service") {
 fun main(vararg args: String) = BracketsService().main(args)
 
 fun wrapService(
-  bindableService: BindableService,
-  vararg interceptors: ServerInterceptor,
+    bindableService: BindableService,
+    vararg interceptors: ServerInterceptor,
 ): GrpcService {
   return GrpcService.builder().addService(bindableService).intercept(*interceptors).build()
 }

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/telemetry/OtelExtensions.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/telemetry/OtelExtensions.kt
@@ -39,72 +39,88 @@ import io.opentelemetry.sdk.trace.export.SpanExporter
 
 /** Creates [Attributes] with [block] configuring the [AttributesBuilder]. */
 fun attributes(block: AttributesBuilder.() -> Unit): Attributes =
-  Attributes.builder().apply(block).build()
+    Attributes.builder().apply(block).build()
 
 /** Creates a [Resource] with [block] configuring its [AttributesBuilder]. */
-fun resource(block: AttributesBuilder.() -> Unit): Resource =
-  Resource.create(attributes(block))
+fun resource(block: AttributesBuilder.() -> Unit): Resource = Resource.create(attributes(block))
 
 /** Merges additional attributes into this [Resource], configured by [block]. */
-fun Resource.merging(block: AttributesBuilder.() -> Unit): Resource =
-  merge(resource(block))
+fun Resource.merging(block: AttributesBuilder.() -> Unit): Resource = merge(resource(block))
 
 // ── SDK providers ────────────────────────────────────────────────────────────
 
-/** Builds an [OpenTelemetrySdk] and registers it as the global, with [block] configuring the builder. */
+/**
+ * Builds an [OpenTelemetrySdk] and registers it as the global, with [block] configuring the
+ * builder.
+ */
 fun openTelemetrySdk(block: OpenTelemetrySdkBuilder.() -> Unit): OpenTelemetrySdk =
-  OpenTelemetrySdk.builder().apply(block).buildAndRegisterGlobal()
+    OpenTelemetrySdk.builder().apply(block).buildAndRegisterGlobal()
 
 /** Builds an [SdkTracerProvider] with [block] configuring the [SdkTracerProviderBuilder]. */
 fun sdkTracerProvider(block: SdkTracerProviderBuilder.() -> Unit): SdkTracerProvider =
-  SdkTracerProvider.builder().apply(block).build()
+    SdkTracerProvider.builder().apply(block).build()
 
 /** Builds an [SdkMeterProvider] with [block] configuring the [SdkMeterProviderBuilder]. */
 fun sdkMeterProvider(block: SdkMeterProviderBuilder.() -> Unit): SdkMeterProvider =
-  SdkMeterProvider.builder().apply(block).build()
+    SdkMeterProvider.builder().apply(block).build()
 
 /** Builds an [SdkLoggerProvider] with [block] configuring the [SdkLoggerProviderBuilder]. */
 fun sdkLoggerProvider(block: SdkLoggerProviderBuilder.() -> Unit): SdkLoggerProvider =
-  SdkLoggerProvider.builder().apply(block).build()
+    SdkLoggerProvider.builder().apply(block).build()
 
 // ── Exporters ────────────────────────────────────────────────────────────────
 
 /** Builds an [OtlpGrpcSpanExporter] with [block] configuring the builder. */
 fun otlpSpanExporter(block: OtlpGrpcSpanExporterBuilder.() -> Unit): OtlpGrpcSpanExporter =
-  OtlpGrpcSpanExporter.builder().apply(block).build()
+    OtlpGrpcSpanExporter.builder().apply(block).build()
 
 /** Builds an [OtlpGrpcMetricExporter] with [block] configuring the builder. */
 fun otlpMetricExporter(block: OtlpGrpcMetricExporterBuilder.() -> Unit): OtlpGrpcMetricExporter =
-  OtlpGrpcMetricExporter.builder().apply(block).build()
+    OtlpGrpcMetricExporter.builder().apply(block).build()
 
 /** Builds an [OtlpGrpcLogRecordExporter] with [block] configuring the builder. */
 fun otlpLogExporter(block: OtlpGrpcLogRecordExporterBuilder.() -> Unit): OtlpGrpcLogRecordExporter =
-  OtlpGrpcLogRecordExporter.builder().apply(block).build()
+    OtlpGrpcLogRecordExporter.builder().apply(block).build()
 
 // ── Processors / readers ─────────────────────────────────────────────────────
 
-/** Builds a [BatchSpanProcessor] for [exporter] with [block] configuring the [BatchSpanProcessorBuilder]. */
-fun batchSpanProcessor(exporter: SpanExporter, block: BatchSpanProcessorBuilder.() -> Unit = {}): BatchSpanProcessor =
-  BatchSpanProcessor.builder(exporter).apply(block).build()
+/**
+ * Builds a [BatchSpanProcessor] for [exporter] with [block] configuring the
+ * [BatchSpanProcessorBuilder].
+ */
+fun batchSpanProcessor(
+    exporter: SpanExporter,
+    block: BatchSpanProcessorBuilder.() -> Unit = {},
+): BatchSpanProcessor = BatchSpanProcessor.builder(exporter).apply(block).build()
 
-/** Builds a [PeriodicMetricReader] for [exporter] with [block] configuring the [PeriodicMetricReaderBuilder]. */
-fun periodicMetricReader(exporter: MetricExporter, block: PeriodicMetricReaderBuilder.() -> Unit = {}): PeriodicMetricReader =
-  PeriodicMetricReader.builder(exporter).apply(block).build()
+/**
+ * Builds a [PeriodicMetricReader] for [exporter] with [block] configuring the
+ * [PeriodicMetricReaderBuilder].
+ */
+fun periodicMetricReader(
+    exporter: MetricExporter,
+    block: PeriodicMetricReaderBuilder.() -> Unit = {},
+): PeriodicMetricReader = PeriodicMetricReader.builder(exporter).apply(block).build()
 
-/** Builds a [BatchLogRecordProcessor] for [exporter] with [block] configuring the [BatchLogRecordProcessorBuilder]. */
-fun batchLogRecordProcessor(exporter: LogRecordExporter, block: BatchLogRecordProcessorBuilder.() -> Unit = {}): BatchLogRecordProcessor =
-  BatchLogRecordProcessor.builder(exporter).apply(block).build()
+/**
+ * Builds a [BatchLogRecordProcessor] for [exporter] with [block] configuring the
+ * [BatchLogRecordProcessorBuilder].
+ */
+fun batchLogRecordProcessor(
+    exporter: LogRecordExporter,
+    block: BatchLogRecordProcessorBuilder.() -> Unit = {},
+): BatchLogRecordProcessor = BatchLogRecordProcessor.builder(exporter).apply(block).build()
 
 // ── Tracer / Meter ───────────────────────────────────────────────────────────
 
 /** Builds and starts a [Span] with [block] configuring the [SpanBuilder]. */
 fun Tracer.span(name: String, block: SpanBuilder.() -> Unit = {}): Span =
-  spanBuilder(name).apply(block).startSpan()
+    spanBuilder(name).apply(block).startSpan()
 
 /** Builds a [LongCounter] with [block] configuring the [LongCounterBuilder]. */
 fun Meter.counter(name: String, block: LongCounterBuilder.() -> Unit = {}): LongCounter =
-  counterBuilder(name).apply(block).build()
+    counterBuilder(name).apply(block).build()
 
 /** Builds a long-valued [LongHistogram] with [block] configuring the [LongHistogramBuilder]. */
 fun Meter.longHistogram(name: String, block: LongHistogramBuilder.() -> Unit = {}): LongHistogram =
-  histogramBuilder(name).ofLongs().apply(block).build()
+    histogramBuilder(name).ofLongs().apply(block).build()

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/telemetry/TelemetrySetup.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/telemetry/TelemetrySetup.kt
@@ -16,8 +16,8 @@ import java.time.Duration
 private val log = KotlinLogging.logger {}
 
 fun initTelemetry(
-  resource: Resource,
-  config: TelemetryConfig,
+    resource: Resource,
+    config: TelemetryConfig,
 ): GrpcOpenTelemetry {
   val sdk = openTelemetrySdk {
     setTracerProvider(buildTracerProvider(resource, config))
@@ -30,36 +30,38 @@ fun initTelemetry(
 
   log.info {
     "OTel SDK initialized: otlpEndpoint=${config.otlpEndpoint ?: "(disabled)"} " +
-      "loggingExport=${config.loggingExportEnabled}"
+        "loggingExport=${config.loggingExportEnabled}"
   }
 
   return GrpcOpenTelemetry.newBuilder().sdk(sdk).build()
 }
 
 private fun buildTracerProvider(resource: Resource, config: TelemetryConfig): SdkTracerProvider =
-  sdkTracerProvider {
-    setResource(resource)
-    if (config.tracingEnabled && config.otlpEndpoint != null) {
-      addSpanProcessor(batchSpanProcessor(otlpSpanExporter { setEndpoint(config.otlpEndpoint) }))
+    sdkTracerProvider {
+      setResource(resource)
+      if (config.tracingEnabled && config.otlpEndpoint != null) {
+        addSpanProcessor(batchSpanProcessor(otlpSpanExporter { setEndpoint(config.otlpEndpoint) }))
+      }
     }
-  }
 
 private fun buildMeterProvider(resource: Resource, config: TelemetryConfig): SdkMeterProvider =
-  sdkMeterProvider {
-    setResource(resource)
-    if (config.metricsEnabled && config.otlpEndpoint != null) {
-      registerMetricReader(
-        periodicMetricReader(otlpMetricExporter { setEndpoint(config.otlpEndpoint) }) {
-          setInterval(Duration.ofSeconds(config.metricsExportIntervalSeconds))
-        }
-      )
+    sdkMeterProvider {
+      setResource(resource)
+      if (config.metricsEnabled && config.otlpEndpoint != null) {
+        registerMetricReader(
+            periodicMetricReader(otlpMetricExporter { setEndpoint(config.otlpEndpoint) }) {
+              setInterval(Duration.ofSeconds(config.metricsExportIntervalSeconds))
+            }
+        )
+      }
     }
-  }
 
 private fun buildLoggerProvider(resource: Resource, config: TelemetryConfig): SdkLoggerProvider =
-  sdkLoggerProvider {
-    setResource(resource)
-    if (config.loggingExportEnabled && config.effectiveLogEndpoint != null) {
-      addLogRecordProcessor(batchLogRecordProcessor(otlpLogExporter { setEndpoint(config.effectiveLogEndpoint) }))
+    sdkLoggerProvider {
+      setResource(resource)
+      if (config.loggingExportEnabled && config.effectiveLogEndpoint != null) {
+        addLogRecordProcessor(
+            batchLogRecordProcessor(otlpLogExporter { setEndpoint(config.effectiveLogEndpoint) })
+        )
+      }
     }
-  }

--- a/kotlin/src/test/kotlin/bracketskt/BracketsTest.kt
+++ b/kotlin/src/test/kotlin/bracketskt/BracketsTest.kt
@@ -8,7 +8,7 @@ import org.junit.Test
 class BracketsTest {
 
   @Test
-  fun testEmptySuccess() { 
+  fun testEmptySuccess() {
     balancedBrackets("")
   }
 
@@ -20,39 +20,52 @@ class BracketsTest {
   @Test
   fun testSimpleBracketsFailRemainingOpen() {
     val err = assertThrows(BracketsNotBalancedException::class.java) { balancedBrackets("(()") }
-    assertThat(err).hasMessageThat().contains("opening brackets without closing brackets found: [(]")
+    assertThat(err)
+        .hasMessageThat()
+        .contains("opening brackets without closing brackets found: [(]")
   }
 
   @Test
   fun testSimpleBracketsFailExtraClosed() {
     val err = assertThrows(BracketsNotBalancedException::class.java) { balancedBrackets("(()))") }
     assertThat(err).hasMessageThat().contains("closing bracket ) with no opening bracket at char 5")
-
   }
 
   @Test
   fun testSimpleBracketsFailMismatched() {
     val err = assertThrows(BracketsNotBalancedException::class.java) { balancedBrackets("((])") }
-    assertThat(err).hasMessageThat().contains("closing bracket ] at char 3 mismatched with last opening bracket (")
+    assertThat(err)
+        .hasMessageThat()
+        .contains("closing bracket ] at char 3 mismatched with last opening bracket (")
   }
 
   @Test
   fun testComplexTextSuccess() {
-    balancedBrackets("This is a bit of (albeit ridiculous) explanatory text. Don't (forget (to nest).).")
+    balancedBrackets(
+        "This is a bit of (albeit ridiculous) explanatory text. Don't (forget (to nest).)."
+    )
   }
 
   @Test
   fun testComplexMixedTextSuccess() {
-    balancedBrackets("This is a bit of (albeit ridiculous) explanatory text. Don't (forget [to {nest}].).")
+    balancedBrackets(
+        "This is a bit of (albeit ridiculous) explanatory text. Don't (forget [to {nest}].)."
+    )
   }
 
   @Test
   fun testComplexTextMismatched() {
-    val err = assertThrows(BracketsNotBalancedException::class.java) {
-      balancedBrackets("This is a bit of (albeit ridiculous] explanatory text. Don't (forget (to nest).).")
-    }
-    assertThat(err).hasMessageThat().contains("closing bracket ] at char 36 mismatched with last opening bracket (")
+    val err =
+        assertThrows(BracketsNotBalancedException::class.java) {
+          balancedBrackets(
+              "This is a bit of (albeit ridiculous] explanatory text. Don't (forget (to nest).)."
+          )
+        }
+    assertThat(err)
+        .hasMessageThat()
+        .contains("closing bracket ] at char 36 mismatched with last opening bracket (")
   }
+
   @Test
   fun testFoo() {
     val actual: Something = foo()

--- a/kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/config/TelemetryConfigTest.kt
+++ b/kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/config/TelemetryConfigTest.kt
@@ -6,7 +6,8 @@ import org.junit.Test
 class TelemetryConfigTest {
   @Test
   fun `effectiveLogEndpoint returns logEndpoint when explicitly set`() {
-    val config = TelemetryConfig(otlpEndpoint = "http://otlp:4317", logEndpoint = "http://logs:4317")
+    val config =
+        TelemetryConfig(otlpEndpoint = "http://otlp:4317", logEndpoint = "http://logs:4317")
     assertThat(config.effectiveLogEndpoint).isEqualTo("http://logs:4317")
   }
 


### PR DESCRIPTION
## Summary

- Apply `ktfmt` (default Google/Meta style, v0.62) to all 11 Kotlin source files — pure formatting, no behavioral changes
- Add ktfmt section to `AGENT.md` instructing agents to run ktfmt before committing any Kotlin file changes

## Test plan

- [x] All Kotlin tests pass locally: `bazel test //kotlin/...` — 2/2 pass
- [x] Full test suite passes: `bazel test //...` — 6/6 pass
- [x] No behavioral changes — formatting only (verified by diff review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)