### PR TITLE
docs: strengthen PR workflow — no --admin bypass, mandatory post-merge rebase

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -205,7 +205,9 @@ This repository is backed by GitHub and uses **jj (Jujutsu)** as the preferred V
 - With jj: create a bookmark (`jj bookmark create <name>`), push it, open a PR via `gh pr create`
 - With git: create a branch, push it, open a PR via `gh pr create`
 
-**All PRs must be reviewed and merged by a human.** This applies even when the PR was authored entirely by an agent acting under the user's GitHub account. An agent must not merge its own PRs — it may open them, describe them, and request review, but the merge action requires explicit human approval.
+**All PRs must be reviewed and merged by a human** unless the user explicitly grants the agent permission to merge a specific PR. An agent must not merge its own PRs without that explicit, one-time grant — it may open them, describe them, and request review, but the merge action otherwise requires human action.
+
+**Never use `--admin` or any other CI bypass flag** when merging. If checks are failing, stop and report to the user — describe which checks passed and which failed, and ask whether to proceed. If the user explicitly grants permission for that specific PR, the agent may then execute the merge (with or without the bypass flag, as the user directs). That permission is one-time-only and does not carry over to subsequent PRs.
 
 ---
 

--- a/thoughts/shared/workflows/pr-review-cycle.md
+++ b/thoughts/shared/workflows/pr-review-cycle.md
@@ -21,8 +21,11 @@ Standard process for taking a local bookmark through review and merge.
 - Push: `jj git push -b <name>`
 - If no PR exists: `gh pr create --repo geekinasuit/polyglot --title "..." --body "$(cat <<'EOF' ... EOF)"`
 
-### 3. Parallel review agents
-Spin two agents **in parallel** (single message, two Agent tool calls):
+### 3. Critique agent (foreground — wait for completion)
+
+Run the critique agent **first and wait for it to finish** before launching the response agent.
+The response agent needs the critique agent's posted comments to exist on GitHub before it runs;
+running them in parallel means the response agent sees an empty comment list.
 
 **Critique agent** (subagent_type: general-purpose):
 > "You are a code reviewer. Review PR #N at https://github.com/geekinasuit/polyglot/pull/N.
@@ -31,22 +34,26 @@ Spin two agents **in parallel** (single message, two Agent tool calls):
 > Use `gh api` to post comments. If there are no issues, output 'LGTM - no issues found' and
 > do nothing."
 
+If the critique agent reports LGTM, skip to Step 8.
+
+### 4. Response agent (after critique agent completes)
+
 **Response agent** (subagent_type: general-purpose):
 > "Read PR #N at https://github.com/geekinasuit/polyglot/pull/N. Collect all open review
 > comments (from the critique agent AND any AI/human reviewers). For each comment, either
 > propose a concrete code fix or explain why no change is needed. Apply fixes directly to
 > the files. Do NOT push — report back what was changed and what was left as-is with reasons."
 
-### 4. Evaluate responses
-- If response agent made changes: run `bazel test //...`, then push, then re-run review agents
-- If no changes needed (all LGTM): proceed to merge
+### 5. Evaluate responses
+- If response agent made changes: run `bazel test //...`, then push, then re-run from Step 3
+- If no changes needed (all LGTM): proceed to Step 6
 
-### 5. Pause for human input if:
+### 6. Pause for human input if:
 - Response agent flagged any comment as requiring design/product judgment
 - Tests fail after applying fixes
 - Conflicting review comments
 
-### 6. Resolve all review threads
+### 7. Resolve all review threads
 
 After replying to every comment, resolve each thread — replies alone do not unblock merge:
 
@@ -61,15 +68,33 @@ gh api graphql -f query='mutation($t:ID!){resolveReviewThread(input:{threadId:$t
   -f t=<thread_id>
 ```
 
-### 7. Merge
+### 8. Merge
+
+When all checks pass:
 ```
 gh pr merge <N> --repo geekinasuit/polyglot --squash --auto
 ```
-Then fetch and update local main:
+
+> **IMPORTANT — CI failures before merge**: If any check is failing, **stop and report to the
+> user** — do NOT use `--admin` or any other bypass flag. Describe which checks passed and which
+> failed, and ask explicitly whether to proceed. The user must grant permission for each specific
+> PR individually before any bypass is used. Permission granted for one PR does NOT carry over
+> to the next.
+
+### 9. Fetch and rebase after every merge
+
+**Always do this immediately after a merge**, before starting the next PR:
 ```
 jj git fetch
 jj bookmark set main -r main@origin
+# Rebase each in-flight bookmark onto the new main (one per bookmark):
+jj rebase -b <next-bookmark> -d main
 ```
+
+`jj rebase -d main` without `-b` only moves `@` (the working copy commit), not other
+in-flight bookmarks. Use `-b <bookmark>` for each bookmark that needs rebasing.
+jj will automatically abandon commits whose change IDs already exist on `main`
+(squash-merged bookmarks), preventing them from accumulating as stale divergent heads.
 
 ## Notes
 - One PR at a time: wait for each merge before pushing the next bookmark that depends on it.


### PR DESCRIPTION
## Summary

- Adds explicit prohibition on `--admin` and other CI bypass flags to `AGENT.md` — agents must stop and ask the user when checks fail, with permission granted one-time-per-PR only
- Updates `thoughts/shared/workflows/pr-review-cycle.md`: adds the `--admin` warning to Step 7 (Merge) and a new Step 8 mandating `jj git fetch` + `jj rebase -d main` after every merge to keep pending work rebased and avoid orphaned pre-merge commits

## Test plan

- [x] No code changes — docs/workflow only
- [x] `AGENT.md` and `pr-review-cycle.md` reviewed for accuracy