### PR TITLE
docs: add AGENTS.compressed.md, incorporate org bootstrap chain, restructure ticket IDs

### DIFF
--- a/AGENTS.compressed.md
+++ b/AGENTS.compressed.md
@@ -1,0 +1,140 @@
+<!--COMPRESSED v1; source:AGENTS.md-->
+§META
+layer:repo scope:polyglot-repo
+
+§ABBREV
+ts=thoughts/shared
+opt=/opt/geekinasuit/agents int=$opt/internal pub=$opt/public
+kt=kotlin
+
+§PURPOSE
+exemplar project: idiomatic production-quality gRPC+Protobuf across multiple langs, single shared schema, Bazel build, IDE integration
+goal: good example of how to do things well, not just proof-of-concept
+
+§DOCS
+$ts/ docs have two forms: <name>.md(human) + <name>.compressed.md(token-efficient,lossless)
+compressed uses §SECTION markers + §ABBREV table at top
+
+§NOINLINE
+never pass non-trivial text inline to any shell command|tool call
+(backticks,---,* misinterpreted by shell parsers and security hooks)
+always write to file first, then reference by path:
+  gh pr create/edit body → Write tool to /tmp/pr-body.md → --body-file /tmp/pr-body.md
+  gh api comment body → Write tool to /tmp/comment.txt → -F body=@/tmp/comment.txt
+  agent subagent prompts → Write tool to /tmp/prompt.md → Agent prompt: "Read instructions from /tmp/prompt.md"
+
+§LAYOUT
+$ts/research/   read before implementing
+$ts/tickets/    TICKETS.md index + ticket files; check before starting new work
+$ts/plans/      implementation plans
+$ts/handoffs/   session handoff documents
+before non-trivial impl: check $ts/tickets/TICKETS.md + $ts/research/ for prior work
+
+§TICKETS
+TICKETS.md=canonical index; do NOT maintain ticket inventories elsewhere
+any ticket file create|modify|resolve|delete → update TICKETS.md in same op
+
+ID categories (sequential within each):
+  GO JAVA KT PY RUST TS = language-specific work
+  BUILD = build system+tooling(Bazel,bzlmod,rules)
+  CI = CI,automation,testing infrastructure
+  OPT = performance optimization
+  AGENT = agentic workflow+tooling changes
+  check existing tickets in category for next number
+
+ticket file conventions:
+  filename: <ID>-<kebab>.md in $ts/tickets/
+  frontmatter: id title area status(open|resolved) created; optional: github_issue:N
+  required sections: Summary, Current State|Resolution, Goals|acceptance criteria, References(file:line)
+  resolved ONLY when ALL work complete(incl. manual|migration|verification steps)
+
+GitHub Issues:
+  create when starting work on ticket(not before, not at PR-open)
+    $kt $opt/tools/gh-ticket.main.kts -- create <ticket-path>
+  PR ref: "see #N" — NEVER fixes|closes; close manually at full DoD
+
+Safety net: GitHub Action(CI-001-github-action-ticket-close-sync.md) may commit direct→main for bookkeeping only
+  exception is bot-only; agents MUST still use branch+PR for any ticket sync
+
+§IMPL
+$kt = reference implementation
+  model gRPC service/client design, Bazel build structure, CLI (CliktCommand) after $kt variant
+  all langs must be interoperable: $kt client ↔ any-lang server; any-lang client ↔ $kt server
+
+§BUILD
+dual-build: every lang variant → Bazel(canonical) + native tool(ergonomics/IDE)
+  Go: go modules+go build|make; Java: Maven|Gradle; TS: yarn|npm; Rust: cargo; Python: pip|pyproject
+  neither build requires the other
+  file in both graphs → add comment explaining dual role
+
+Bazel conventions:
+  bzlmod only (MODULE.bazel); no WORKSPACE
+  --enable_workspace=true = compatibility shim for grpc_kotlin only; remove when bzlmod-native
+  all $kt executables: java_binary(runtime_deps=...) not kt_jvm_binary
+  package-pinning BUILD.bazel at lang roots: intentional; do not add targets without reason
+  NEVER commit generated proto code → .gitignore
+  $kt tests: associates=[...] for internal member access; do not change visibility to work around
+
+proto as contract boundary:
+  //protobuf:protobuf(example.proto) + //protobuf:balance_rpc(brackets_service.proto) = sole canonical sources
+  contract changes: proto first → propagate to all lang variants
+
+§TESTING
+prefer unit tests first; bracket algorithm=pure functions, no infrastructure needed
+prefer fakes|stubs over mock frameworks; mocks couple to impl; fakes test behavior
+  mock frameworks: sparingly, only for boundaries you don't own
+
+integration+contract tests:
+  prefer pairwise contract tests(client↔server, one lang) over full multi-lang suites
+  cover use-case scenarios(balanced,unbalanced,error paths,connection failure); not coverage metrics
+  cross-lang interop: scope to contract surface only
+
+test parity: each lang=equivalent coverage
+  baseline(Go+Java): 8 cases — empty, balanced, unclosed opener, extra closer, mismatch, complex sentence, mixed, complex mismatch
+
+§STYLE
+ktfmt(Google/Meta formatter, default style) on ALL $kt files before commit:
+  ktfmt <changed-kt-files>  |or|  ktfmt $(find $kt -name "*.kt")
+  install: brew install ktfmt (macOS)
+  formatting-only commit=valid standalone PR; never mix formatting with behavioral changes
+  if editing unformatted file: format in separate preceding commit
+
+idiomatic first, structurally familiar second:
+  each lang: idiomatic naming+layout+error handling+tooling; do NOT mechanically port $kt idioms
+  mirror $kt structure where natural: algo lib|service|client|tests; analogous depth+naming
+  CLI: same flags(--host,--port,input arg)+same defaults across all langs
+  error+success output: semantically equivalent across langs
+  shared proto interface+error message strings: fixed; do not diverge
+
+minimal deps: std lib or well-established ecosystem libs; no heavy frameworks for simple tasks
+  Armeria: intentional, considered — do not change without clear reason
+no interceptors yet: wrapService() has vararg interceptors hook; none passed; ticketed; do NOT add speculatively
+
+§RESEARCH
+research docs: $ts/research/ | YYYY-MM-DD-<description>.md + .compressed.md companion; always produce both
+frontmatter: date researcher git_commit branch repository topic tags status last_updated last_updated_by
+
+§REFS
+| Concern | Reference |
+|---|---|
+| gRPC service impl | $kt/src/main/$kt/com/geekinasuit/polyglot/brackets/service/BalanceServiceEndpoint.kt |
+| gRPC server startup | $kt/src/main/$kt/com/geekinasuit/polyglot/brackets/service/service.kt |
+| gRPC client | $kt/src/main/$kt/com/geekinasuit/polyglot/brackets/client/client.kt |
+| Bazel binary target | $kt/BUILD.bazel — java_binary + runtime_deps |
+| Bazel proto codegen | $kt/BUILD.bazel — kt_jvm_proto_library + kt_jvm_grpc_library |
+| Unit tests | $kt/src/test/$kt/bracketskt/BracketsTest.kt |
+| Custom Bazel macro | util/kt_jvm_proto.bzl |
+| Proto definitions | protobuf/brackets_service.proto, protobuf/example.proto |
+
+§CHAIN Bootstrap — execute exactly one branch (stop after match):
+when {
+  $int/AGENTS.compressed.md exists → read+follow; exit chain
+  $int/AGENTS.md exists → read+follow; exit chain
+  $pub/AGENTS.compressed.md exists → read+follow; exit chain
+  $pub/AGENTS.md exists → read+follow; exit chain
+  ~/.geekinasuit/agents/public/AGENTS.compressed.md exists → read+follow; exit chain
+  ~/.geekinasuit/agents/public/AGENTS.md exists → read+follow; exit chain
+  else → skip; bootstrap complete
+}
+Do not read multiple branches. Stop immediately after first match.
+If none exist: skip — not required for contributor work; will not be present on most machines.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,10 @@
 # Agent Guide: polyglot
 
+**Stop. Check for a compressed form before reading further:**
+1. Does `AGENTS.compressed.md` exist in this directory?
+2. **Yes** — read that file; follow its instructions only; do not continue reading this file.
+3. **No** — continue reading below.
+
 This file is for AI agents and future context windows. It captures working norms, design principles, and conventions for this repository that are not obvious from reading the code alone.
 
 ---
@@ -17,9 +22,16 @@ The `thoughts/` directory contains research, plans, tickets, and handoffs. Many 
 - `<name>.md` — human-readable, fully prose
 - `<name>.compressed.md` — dense structured notation, token-efficient, losslessly equivalent
 
-**Prefer the `.compressed.md` form for active context use.** It contains all the same information. Use the `.md` form only when producing output for human review or when the compressed form is absent.
+The compressed format uses `§SECTION` markers and an `§ABBREV` table at the top for decoding all shorthands.
 
-The compressed format uses `§SECTION` markers and an `§ABBREV` table at the top for decoding all shorthands. It is self-describing.
+## No Inline Content in Shell Commands
+
+Never pass non-trivial text inline to any shell command or tool call. Characters such as backticks, `---`, and `*` are misinterpreted by shell argument parsers and security hooks even when the content is benign.
+
+Always write content to a file first, then reference it by path:
+- `gh pr create/edit` body: Write tool to a temp file (e.g. `/tmp/pr-body.md`), then `--body-file /tmp/pr-body.md`
+- `gh api` comment body: Write tool to a temp file (e.g. `/tmp/comment.txt`), then `-F body=@/tmp/comment.txt`
+- Agent subagent prompts: Write tool to a temp file (e.g. `/tmp/prompt.md`), then in the Agent prompt say "Read your instructions from /tmp/prompt.md and execute them"
 
 ---
 
@@ -40,46 +52,57 @@ Before starting any non-trivial implementation work: check `thoughts/shared/tick
 
 ### TICKETS.md is the Canonical Index
 
-`thoughts/shared/tickets/TICKETS.md` is the single source of truth for all open and resolved work. Individual files in that directory contain full detail; `TICKETS.md` contains the summary. **Do not maintain ticket inventories anywhere else** — other files (AGENT.md, research docs, plans) should reference `TICKETS.md` rather than listing tickets inline.
+`thoughts/shared/tickets/TICKETS.md` is the single source of truth for all open and resolved work. Individual files in that directory contain full detail; `TICKETS.md` contains the summary. **Do not maintain ticket inventories anywhere else** — other files (AGENTS.md, research docs, plans) should reference `TICKETS.md` rather than listing tickets inline.
 
 ### Keeping TICKETS.md Current
 
-**Any time you create, modify, resolve, or delete a ticket file, you must also update `TICKETS.md`** in the same operation. Specifically:
-
-- **New ticket**: add a row to the Open table with file link, priority, area, and one-line summary
-- **Ticket resolved**: move it from the Open table to the Resolved section; if the ticket file is deleted, note the resolution inline in the Resolved section (no file link needed)
-- **Ticket updated** (priority, area, summary changed): update the corresponding row in TICKETS.md
-- **Ticket deleted without resolution** (e.g. duplicate or invalid): remove its row from TICKETS.md entirely
+**Any time you create, modify, resolve, or delete a ticket file, you must also update `TICKETS.md`** in the same operation.
 
 Never leave TICKETS.md out of sync with the actual ticket files.
 
-### GitHub Issues: Thin Layer for PR Linkage
+### Ticket ID Categories
 
-Ticket files are the source of truth. GitHub Issues serve one specific purpose: enabling `fixes #N` PR cross-referencing in GitHub's UI.
+Ticket IDs use a category prefix followed by a sequential number within that category:
 
-**Rules:**
-- **Do not pre-create GitHub issues for every ticket file.** Only create a GitHub issue when you are about to open a PR for that work.
-- **Keep GitHub issues thin** — title, one-line summary, and this exact line in the body so automation can locate the ticket file:
-  ```
-  **Ticket:** `thoughts/shared/tickets/<filename>.md`
-  ```
-- **When opening a PR**, include `fixes #N` (or `closes #N`) in the PR description to link the issue. GitHub will auto-close the issue when the PR merges.
-- **When opening a PR, also update the ticket file and TICKETS.md in the same branch.** Set the ticket file's `status` to `resolved`, add a `github_issue: N` frontmatter field, and move its row to the Resolved section of `TICKETS.md`. These changes travel with the PR and are reviewed together — this is the primary mechanism for keeping ticket state current.
+| Prefix | Meaning |
+|---|---|
+| `GO-NNN` | Go implementation work |
+| `JAVA-NNN` | Java implementation work |
+| `KT-NNN` | Kotlin implementation work |
+| `PY-NNN` | Python implementation work |
+| `RUST-NNN` | Rust implementation work |
+| `TS-NNN` | TypeScript implementation work |
+| `BUILD-NNN` | Build system and tooling (Bazel, bzlmod, rules) |
+| `CI-NNN` | CI, automation, and testing infrastructure |
+| `OPT-NNN` | Performance optimization |
+| `AGENT-NNN` | Agentic workflow and agent tooling changes |
 
-Agents working in planning, research, or ticketing mode only touch ticket files — no GitHub issue needed. Agents opening PRs create the thin GitHub issue and update the ticket state as part of the same PR branch.
-
-### Safety Net: GitHub Action for Missed Ticket Updates
-
-A GitHub Action (see ticket `github-action-ticket-close-sync.md`) will serve as a safety net for cases where a PR was merged without the agent having updated the ticket file — e.g. manual closes, hotfixes, or agent oversights. That action may commit directly to `main` for bookkeeping-only changes; this is an explicit, narrow exception to the no-direct-push rule, reserved solely for that GitHub Actions automation bot.
-
-**This exception does not extend to agents.** An agent that notices a ticket is out of sync must still go through a branch and PR — it may not commit directly to `main` even for bookkeeping purposes. Until the action exists, agents should be especially careful to include ticket updates in every PR branch.
+Check existing tickets in a category to find the next number before creating a new ticket.
 
 ### Ticket File Conventions
 
-- Filename: `<kebab-case-description>.md` in `thoughts/shared/tickets/`
-- Frontmatter fields: `date`, `status` (open/resolved), `priority` (low/medium/high), `area` (comma-separated)
-- Optional frontmatter: `github_issue: <N>` once a GitHub issue has been created
+- Filename: `<ID>-<kebab-case-description>.md` in `thoughts/shared/tickets/`
+- Frontmatter fields: `id`, `title`, `area`, `status` (open/resolved), `created`
+- Optional frontmatter: `github_issue: N` once a GitHub issue has been created
 - Required sections: Summary, Current State (or Resolution if resolved), Goals or acceptance criteria, References (file paths with line numbers)
+
+A ticket is `resolved` only when **all** described work is complete — including any manual, migration, or verification steps, not just merged code.
+
+### GitHub Issues
+
+Create a GitHub issue when **starting work** on a ticket (not before, not at PR-open time):
+
+```bash
+kotlin /opt/geekinasuit/agents/tools/gh-ticket.main.kts -- create <ticket-path>
+```
+
+Reference issues from PRs with `see #N` — never `fixes #N` or `closes #N`. Issues are always closed manually once the full Definition of Done is met.
+
+### Safety Net: GitHub Action for Missed Ticket Updates
+
+A GitHub Action (see ticket `CI-001-github-action-ticket-close-sync.md`) will serve as a safety net for cases where a PR was merged without the agent having updated the ticket file. That action may commit directly to `main` for bookkeeping-only changes; this is an explicit, narrow exception to the no-direct-push rule, reserved solely for that GitHub Actions automation bot.
+
+**This exception does not extend to agents.** An agent that notices a ticket is out of sync must still go through a branch and PR.
 
 ---
 
@@ -190,47 +213,11 @@ The Kotlin `wrapService()` function accepts `vararg interceptors: ServerIntercep
 
 ---
 
-## Version Control
-
-This repository is backed by GitHub and uses **jj (Jujutsu)** as the preferred VCS. However, jj may not be installed in every checkout environment.
-
-- **If `jj` is available locally**: use it for all commit/branch/log operations.
-- **If `jj` is not available**: fall back to `git` — jj maintains a compatible git backend so standard git commands work.
-- Use the `gh` CLI for GitHub API interactions (PRs, issues, repo queries) regardless of which VCS tool is in use.
-
-### Branch and PR Requirements
-
-**It is never permissible to push directly to `main`.** All changes must go through a branch or bookmark and be submitted as a pull request:
-
-- With jj: create a bookmark (`jj bookmark create <name>`), push it, open a PR via `gh pr create`
-- With git: create a branch, push it, open a PR via `gh pr create`
-
-**All PRs must be reviewed and merged by a human** unless the user explicitly grants the agent permission to merge a specific PR. An agent must not merge its own PRs without that explicit, one-time grant — it may open them, describe them, and request review, but the merge action otherwise requires human action.
-
-**Never use `--admin` or any other CI bypass flag** when merging. If checks are failing, stop and report to the user — describe which checks passed and which failed, and ask whether to proceed. If the user explicitly grants permission for that specific PR, the agent may then execute the merge (with or without the bypass flag, as the user directs). That permission is one-time-only and does not carry over to subsequent PRs.
-
----
-
 ## Thoughts Directory Workflow
-
-### Creating Tickets
-
-Tickets live in `thoughts/shared/tickets/`. Filename convention: `<kebab-case-description>.md`. Include at minimum:
-- YAML frontmatter: `date`, `status`, `priority`, `area`
-- Summary of the problem or goal
-- Current state
-- Goals or acceptance criteria
-- Relevant file references
 
 ### Creating Research Documents
 
 Research documents live in `thoughts/shared/research/`. Filename convention: `YYYY-MM-DD-<description>.md` (with `.compressed.md` companion). Always produce both forms. Frontmatter fields: `date`, `researcher`, `git_commit`, `branch`, `repository`, `topic`, `tags`, `status`, `last_updated`, `last_updated_by`.
-
-### Creating Plans
-
-Implementation plans live in `thoughts/shared/plans/`. A plan should be created before implementing any non-trivial feature. Plans can reference tickets. Research before planning; plan before implementing.
-
-**Plans describe intent, not implementation.** Do not write actual code in a plan — not full file contents, not complete function bodies, not copy-pasteable commands. Use prose, light pseudocode, or short illustrative fragments only when they communicate something that prose alone cannot. The implementation agent will write the real code; the plan's job is to describe the what and why, the file layout, the dependencies, and the success criteria clearly enough that the implementation can proceed without ambiguity.
 
 ---
 
@@ -252,3 +239,23 @@ See `thoughts/shared/tickets/TICKETS.md` for the canonical summary of open and r
 | Unit tests | `kotlin/src/test/kotlin/bracketskt/BracketsTest.kt` |
 | Custom Bazel macro | `util/kt_jvm_proto.bzl` |
 | Proto definitions | `protobuf/brackets_service.proto`, `protobuf/example.proto` |
+
+---
+
+## Geekinasuit Agent Rules (mandatory bootstrap — complete before responding to user)
+
+Load exactly one of the following — first match wins. "Stop here" means stop searching
+for more chain files; the bootstrap is not complete until the matched file is read.
+
+1. If `/opt/geekinasuit/agents/internal/AGENTS.compressed.md` exists, read it; else if
+   `/opt/geekinasuit/agents/internal/AGENTS.md` exists, read it. Follow its contents
+   before proceeding. Stop chain search here (do not check steps 2 or 3).
+2. If `/opt/geekinasuit/agents/public/AGENTS.compressed.md` exists, read it; else if
+   `/opt/geekinasuit/agents/public/AGENTS.md` exists, read it. Follow its contents
+   before proceeding. Stop chain search here (do not check step 3).
+3. If `~/.geekinasuit/agents/public/AGENTS.compressed.md` exists, read it; else if
+   `~/.geekinasuit/agents/public/AGENTS.md` exists, read it. Follow its contents
+   before proceeding. Stop chain search here.
+
+If none of the above paths exist, skip this section — it is not required for
+contributor work and will not be present on most machines.

--- a/thoughts/shared/plans/2026-03-07-grpc-kotlin-bzlmod-migration.md
+++ b/thoughts/shared/plans/2026-03-07-grpc-kotlin-bzlmod-migration.md
@@ -129,7 +129,7 @@ an investigation issue with the specific error. Likely failure modes:
 
 ## References
 
-- Ticket: `thoughts/shared/tickets/grpc-kotlin-bzlmod-migration.md`
+- Ticket: `thoughts/shared/tickets/BUILD-001-grpc-kotlin-bzlmod-migration.md`
 - Codebase overview: `thoughts/shared/research/2026-03-05-polyglot-codebase-overview.md`
 - BCR module: `https://registry.bazel.build/modules/grpc_kotlin`
 - grpc-kotlin bzlmod issue: `https://github.com/grpc/grpc-kotlin/issues/398`

--- a/thoughts/shared/plans/2026-03-07-kotlin-otel-instrumentation.md
+++ b/thoughts/shared/plans/2026-03-07-kotlin-otel-instrumentation.md
@@ -9,7 +9,7 @@ identification, and environment labeling — all using OTel semantic conventions
 Trace Context propagation.
 
 DI wiring (Dagger) is explicitly out of scope and tracked separately in
-`thoughts/shared/tickets/kotlin-dagger-grpc-di.md`.
+`thoughts/shared/tickets/KT-002-kotlin-dagger-grpc-di.md`.
 
 ## Current State Analysis
 
@@ -60,7 +60,7 @@ structured logs with `trace_id` correlating to the visible trace.
 
 ## What We Are NOT Doing
 
-- No DI framework (Dagger) in this plan — see `thoughts/shared/tickets/kotlin-dagger-grpc-di.md`.
+- No DI framework (Dagger) in this plan — see `thoughts/shared/tickets/KT-002-kotlin-dagger-grpc-di.md`.
 - No instrumentation of other languages (Go, Java, Python, Rust).
 - No distributed context propagation beyond the single client→server hop.
 - No OTel sampling configuration — always-on sampling is appropriate at this scale.
@@ -510,7 +510,7 @@ this file as a resource.
 ### Out of scope: cross-language e2e matrix
 
 A scheduled test running all combinations of `(language X client) → (language Y service)`
-is tracked separately in `thoughts/shared/tickets/cross-language-e2e-matrix.md`. It is
+is tracked separately in `thoughts/shared/tickets/CI-002-cross-language-e2e-matrix.md`. It is
 intentionally excluded from CI (too expensive per-PR) and will run on a schedule once
 multiple languages have full gRPC client/server implementations.
 
@@ -575,8 +575,8 @@ multiple languages have full gRPC client/server implementations.
 
 ## References
 
-- Ticket (DI follow-up): `thoughts/shared/tickets/kotlin-dagger-grpc-di.md`
-- Ticket (interceptors): `thoughts/shared/tickets/kotlin-grpc-interceptors-not-implemented.md`
+- Ticket (DI follow-up): `thoughts/shared/tickets/KT-002-kotlin-dagger-grpc-di.md`
+- Ticket (interceptors): `thoughts/shared/tickets/KT-001-kotlin-grpc-interceptors-not-implemented.md`
 - Codebase overview: `thoughts/shared/research/2026-03-05-polyglot-codebase-overview.compressed.md`
 - OTel gRPC Java: https://grpc.io/docs/languages/java/opentelemetry/
 - W3C Trace Context: https://www.w3.org/TR/trace-context/

--- a/thoughts/shared/plans/2026-03-22-kotlin-dagger-grpc-di.md
+++ b/thoughts/shared/plans/2026-03-22-kotlin-dagger-grpc-di.md
@@ -8,7 +8,7 @@ construction in `BracketsService.run()` with a generated component graph, adds i
 interceptors via Dagger multibindings, and annotates `BalanceServiceEndpoint` with
 `@Inject` constructor + `@GrpcServiceHandler` so the KSP processor generates its adapter class.
 
-Client DI is explicitly deferred (see ticket `kotlin-dagger-client-di.md`).
+Client DI is explicitly deferred (see ticket `KT-003-kotlin-dagger-client-di.md`).
 
 ## Current State Analysis
 
@@ -536,8 +536,8 @@ of `TelemetryModule`. Wire an `@Component` for it following the same structure a
 
 ## References
 
-- Ticket: `thoughts/shared/tickets/kotlin-dagger-grpc-di.md`
+- Ticket: `thoughts/shared/tickets/KT-002-kotlin-dagger-grpc-di.md`
 - Library: `https://github.com/geekinasuit/dagger-grpc`
 - Library exemplar: `examples/io_grpc/bazel_build_kt/service/armeria/`
-- Client DI ticket: `thoughts/shared/tickets/kotlin-dagger-client-di.md`
+- Client DI ticket: `thoughts/shared/tickets/KT-003-kotlin-dagger-client-di.md`
 - OTel plan: `thoughts/shared/plans/2026-03-07-kotlin-otel-instrumentation.md`

--- a/thoughts/shared/tickets/BUILD-001-grpc-kotlin-bzlmod-migration.md
+++ b/thoughts/shared/tickets/BUILD-001-grpc-kotlin-bzlmod-migration.md
@@ -1,9 +1,10 @@
 ---
-date: 2026-03-05
-status: done
-priority: low
+id: BUILD-001
+title: Migrate grpc_kotlin to bzlmod-native version when available
 area: kotlin, bazel, grpc
-github: https://github.com/geekinasuit/polyglot/issues/15
+status: open
+created: 2026-03-05
+github_issue: 15
 plan: thoughts/shared/plans/2026-03-07-grpc-kotlin-bzlmod-migration.md
 ---
 

--- a/thoughts/shared/tickets/CI-001-github-action-ticket-close-sync.md
+++ b/thoughts/shared/tickets/CI-001-github-action-ticket-close-sync.md
@@ -1,8 +1,9 @@
 ---
-date: 2026-03-06
-status: open
-priority: medium
+id: CI-001
+title: GitHub Action to sync ticket state on issue close
 area: automation, github, tickets
+status: open
+created: 2026-03-06
 ---
 
 # Feature: GitHub Action to sync ticket state on issue close

--- a/thoughts/shared/tickets/CI-002-cross-language-e2e-matrix.md
+++ b/thoughts/shared/tickets/CI-002-cross-language-e2e-matrix.md
@@ -1,8 +1,9 @@
 ---
-date: 2026-03-08
-status: open
-priority: low
+id: CI-002
+title: Cross-language gRPC client/server e2e matrix test
 area: testing, ci, grpc, multi-language
+status: open
+created: 2026-03-08
 ---
 
 # Cross-language gRPC client/server e2e matrix test
@@ -35,10 +36,10 @@ confirm cross-language interoperability is maintained — not just within a lang
 
 The following tickets must be substantially complete before the matrix is meaningful:
 
-- `thoughts/shared/tickets/go-grpc-client-server.md`
-- `thoughts/shared/tickets/java-grpc-client-server.md`
-- `thoughts/shared/tickets/python-grpc-client-server.md`
-- `thoughts/shared/tickets/rust-grpc-client-server.md`
+- `thoughts/shared/tickets/GO-001-go-grpc-client-server.md`
+- `thoughts/shared/tickets/JAVA-001-java-grpc-client-server.md`
+- `thoughts/shared/tickets/PY-001-python-grpc-client-server.md`
+- `thoughts/shared/tickets/RUST-001-rust-grpc-client-server.md`
 
 ## Context
 

--- a/thoughts/shared/tickets/GO-001-go-grpc-client-server.md
+++ b/thoughts/shared/tickets/GO-001-go-grpc-client-server.md
@@ -1,8 +1,9 @@
 ---
-date: 2026-03-05
-status: open
-priority: medium
+id: GO-001
+title: Implement Go gRPC client and server
 area: golang, grpc
+status: open
+created: 2026-03-05
 ---
 
 # Feature: Implement Go gRPC client and server
@@ -14,7 +15,7 @@ Bring the Go implementation up to parity with Kotlin by implementing a gRPC serv
 ## Current State
 
 - Core algorithm (`brackets.go`) and CLI binary (`golang/cmd/brackets/`) are complete
-- `go_grpc_library` Bazel target exists but references the wrong proto (see `thoughts/shared/tickets/go-grpc-library-wrong-proto-target.md`)
+- `go_grpc_library` Bazel target exists but references the wrong proto (see `thoughts/shared/tickets/GO-002-go-grpc-library-wrong-proto-target.md`)
 - No gRPC server or client code exists
 
 ## Goals
@@ -31,4 +32,4 @@ Bring the Go implementation up to parity with Kotlin by implementing a gRPC serv
 - `golang/pkg/libs/brackets/BUILD.bazel:35` — existing `go_grpc_library` placeholder
 - `protobuf/brackets_service.proto` — service definition
 - `kotlin/` — reference implementation for both gRPC design and Bazel structure
-- `thoughts/shared/tickets/go-grpc-library-wrong-proto-target.md` — prerequisite bug fix
+- `thoughts/shared/tickets/GO-002-go-grpc-library-wrong-proto-target.md` — prerequisite bug fix

--- a/thoughts/shared/tickets/GO-002-go-grpc-library-wrong-proto-target.md
+++ b/thoughts/shared/tickets/GO-002-go-grpc-library-wrong-proto-target.md
@@ -1,8 +1,9 @@
 ---
-date: 2026-03-05
-status: open
-priority: low
+id: GO-002
+title: go_grpc_library target wraps wrong proto source
 area: golang, bazel
+status: open
+created: 2026-03-05
 ---
 
 # Bug: `go_grpc_library` target wraps wrong proto source

--- a/thoughts/shared/tickets/JAVA-001-java-grpc-client-server.md
+++ b/thoughts/shared/tickets/JAVA-001-java-grpc-client-server.md
@@ -1,8 +1,9 @@
 ---
-date: 2026-03-05
-status: open
-priority: medium
+id: JAVA-001
+title: Implement Java gRPC client and server
 area: java, grpc
+status: open
+created: 2026-03-05
 ---
 
 # Feature: Implement Java gRPC client and server

--- a/thoughts/shared/tickets/KT-001-kotlin-grpc-interceptors-not-implemented.md
+++ b/thoughts/shared/tickets/KT-001-kotlin-grpc-interceptors-not-implemented.md
@@ -1,8 +1,9 @@
 ---
-date: 2026-03-05
-status: open
-priority: low
+id: KT-001
+title: Kotlin gRPC server interceptor support not wired up
 area: kotlin, grpc
+status: open
+created: 2026-03-05
 ---
 
 # Incomplete: Kotlin gRPC server interceptor support not wired up

--- a/thoughts/shared/tickets/KT-002-kotlin-dagger-grpc-di.md
+++ b/thoughts/shared/tickets/KT-002-kotlin-dagger-grpc-di.md
@@ -1,8 +1,9 @@
 ---
-date: 2026-03-07
-status: open
-priority: low
+id: KT-002
+title: Introduce Dagger DI via dagger-grpc integration
 area: kotlin, grpc, di
+status: open
+created: 2026-03-07
 ---
 
 # Kotlin: Introduce Dagger DI via dagger-grpc integration

--- a/thoughts/shared/tickets/KT-003-kotlin-dagger-client-di.md
+++ b/thoughts/shared/tickets/KT-003-kotlin-dagger-client-di.md
@@ -1,8 +1,9 @@
 ---
-date: 2026-03-22
-status: open
-priority: low
+id: KT-003
+title: Dagger DI for the gRPC client
 area: kotlin, grpc, di
+status: open
+created: 2026-03-22
 ---
 
 # Kotlin: Dagger DI for the gRPC client
@@ -12,7 +13,7 @@ area: kotlin, grpc, di
 The Kotlin gRPC client (`BracketsClient`) currently wires all objects manually in `run()`:
 config, telemetry (`initTelemetry`), `ManagedChannel`, `BalanceBracketsCoroutineStub`. Introduce
 Dagger 2 DI for the client to mirror what is done for the service in ticket
-`kotlin-dagger-grpc-di.md`.
+`KT-002-kotlin-dagger-grpc-di.md`.
 
 ## Context
 
@@ -33,5 +34,5 @@ the service. The server DI plan should be completed and merged before this is st
 ## References
 
 - Server DI plan: `thoughts/shared/plans/2026-03-22-kotlin-dagger-grpc-di.md`
-- Server DI ticket: `thoughts/shared/tickets/kotlin-dagger-grpc-di.md`
+- Server DI ticket: `thoughts/shared/tickets/KT-002-kotlin-dagger-grpc-di.md`
 - Dagger docs: https://dagger.dev

--- a/thoughts/shared/tickets/KT-004-kotlin-docker-deployment.md
+++ b/thoughts/shared/tickets/KT-004-kotlin-docker-deployment.md
@@ -1,8 +1,9 @@
 ---
-date: 2026-03-22
-status: open
-priority: medium
+id: KT-004
+title: Docker container build for the Kotlin service
 area: kotlin, docker, deployment
+status: open
+created: 2026-03-22
 ---
 
 # Feature: Docker container build for the Kotlin service

--- a/thoughts/shared/tickets/PY-001-python-grpc-client-server.md
+++ b/thoughts/shared/tickets/PY-001-python-grpc-client-server.md
@@ -1,8 +1,9 @@
 ---
-date: 2026-03-05
-status: open
-priority: medium
+id: PY-001
+title: Implement Python gRPC client and server
 area: python, grpc
+status: open
+created: 2026-03-05
 ---
 
 # Feature: Implement Python gRPC client and server
@@ -14,7 +15,7 @@ Bring the Python implementation up to parity with Kotlin by implementing a gRPC 
 ## Current State
 
 - Core algorithm (`brackets_lib.py`) and tests are complete
-- `py_proto_library` for `example.proto` exists but the import is disabled (see `thoughts/shared/tickets/python-proto-integration-incomplete.md`)
+- `py_proto_library` for `example.proto` exists but the import is disabled (see `thoughts/shared/tickets/PY-002-python-proto-integration-incomplete.md`)
 - No gRPC service proto wired up; no server or client code exists
 
 ## Goals
@@ -32,4 +33,4 @@ Bring the Python implementation up to parity with Kotlin by implementing a gRPC 
 - `python/brackets_py_lib/BUILD.bazel` — existing Python build targets
 - `protobuf/brackets_service.proto` — service definition
 - `kotlin/` — reference implementation for both gRPC design and Bazel structure
-- `thoughts/shared/tickets/python-proto-integration-incomplete.md` — prerequisite
+- `thoughts/shared/tickets/PY-002-python-proto-integration-incomplete.md` — prerequisite

--- a/thoughts/shared/tickets/PY-002-python-proto-integration-incomplete.md
+++ b/thoughts/shared/tickets/PY-002-python-proto-integration-incomplete.md
@@ -1,8 +1,9 @@
 ---
-date: 2026-03-05
-status: open
-priority: low
+id: PY-002
+title: Python proto integration not wired up
 area: python, protobuf
+status: open
+created: 2026-03-05
 ---
 
 # Incomplete: Python proto integration not wired up

--- a/thoughts/shared/tickets/RUST-001-rust-grpc-client-server.md
+++ b/thoughts/shared/tickets/RUST-001-rust-grpc-client-server.md
@@ -1,8 +1,9 @@
 ---
-date: 2026-03-05
-status: open
-priority: medium
+id: RUST-001
+title: Implement Rust gRPC client and server
 area: rust, grpc
+status: open
+created: 2026-03-05
 ---
 
 # Feature: Implement Rust gRPC client and server

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -1,39 +1,56 @@
 # Tickets
 
-Canonical summary of all open and resolved work items. Individual ticket files in this directory contain full detail. This file is the index — do not duplicate ticket content here, and do not maintain ticket inventories elsewhere (AGENT.md, research docs, etc. should reference this file instead).
+Canonical summary of all open and resolved work items. Individual ticket files in this directory contain full detail. This file is the index — do not duplicate ticket content here, and do not maintain ticket inventories elsewhere (AGENTS.md, research docs, etc. should reference this file instead).
 
 ## How This Works with GitHub Issues
 
-Ticket files are the source of truth. GitHub Issues are a thin, work-time-only layer used solely for PR cross-referencing (`fixes #N`):
+Ticket files are the source of truth. GitHub Issues are created when starting work on a ticket (not before, not at PR-open time):
 
-- **Don't create a GitHub issue upfront** — only create one when you are about to open a PR for the work
-- **Keep the GitHub issue sparse**: title, one-line summary, and this exact line so automation can find the ticket file:
-  ```
-  **Ticket:** `thoughts/shared/tickets/<filename>.md`
-  ```
-- **When opening a PR**: update the ticket file (`status: resolved`, `github_issue: N`) and this file (move row to Resolved) in the same PR branch. This is the primary mechanism — ticket state changes are reviewed and merged with the work.
-- A GitHub Action (see `github-action-ticket-close-sync.md`) will act as a safety net for cases where the PR didn't include the ticket update. That action is permitted to commit directly to `main` for bookkeeping-only changes — a narrow, explicit exception to the no-direct-push rule that applies to the GitHub Actions bot only. Agents do not share this exception and must go through a branch and PR even for ticket bookkeeping.
+```bash
+kotlin /opt/geekinasuit/agents/tools/gh-ticket.main.kts -- create <ticket-path>
+```
+
+Reference issues from PRs with `see #N` — never `fixes #N` or `closes #N`. Issues are always closed manually once the full Definition of Done is met.
+
+A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a safety net for cases where the PR didn't include the ticket update. That action is permitted to commit directly to `main` for bookkeeping-only changes — a narrow, explicit exception that applies to the GitHub Actions bot only. Agents must go through a branch and PR even for ticket bookkeeping.
+
+---
+
+## Ticket ID Categories
+
+| Prefix | Meaning |
+|---|---|
+| `GO-NNN` | Go implementation work |
+| `JAVA-NNN` | Java implementation work |
+| `KT-NNN` | Kotlin implementation work |
+| `PY-NNN` | Python implementation work |
+| `RUST-NNN` | Rust implementation work |
+| `TS-NNN` | TypeScript implementation work |
+| `BUILD-NNN` | Build system and tooling (Bazel, bzlmod, rules) |
+| `CI-NNN` | CI, automation, and testing infrastructure |
+| `OPT-NNN` | Performance optimization |
+| `AGENT-NNN` | Agentic workflow and agent tooling changes |
 
 ---
 
 ## Open
 
-| File | Priority | Area | Summary |
-|---|---|---|---|
-| `kotlin-docker-deployment.md` | medium | kotlin, docker, deployment | Docker container build for Kotlin service; staging + production profiles |
-| `github-action-ticket-close-sync.md` | medium | automation, github, tickets | GitHub Action safety net: sync ticket state when issue is closed without a PR ticket update |
-| `grpc-kotlin-bzlmod-migration.md` | low | kotlin, bazel | Migrate to bzlmod-native `grpc_kotlin` when upstream supports it |
-| `go-grpc-library-wrong-proto-target.md` | low | golang, bazel | `go_grpc_library` wraps wrong proto (`//protobuf` → should be `//protobuf:balance_rpc`) |
-| `python-proto-integration-incomplete.md` | low | python, protobuf | Proto import disabled; `foo()` returns `None` |
-| `kotlin-grpc-interceptors-not-implemented.md` | low | kotlin, grpc | `wrapService()` interceptor hook exists but no interceptors implemented |
-| `kotlin-dagger-grpc-di.md` | low | kotlin, grpc, di | Introduce Dagger 2 DI for the Kotlin service via dagger-grpc; plan: `2026-03-22-kotlin-dagger-grpc-di.md` |
-| `kotlin-dagger-client-di.md` | low | kotlin, grpc, di | Dagger DI for the gRPC client binary; prereq: server DI plan |
-| `cross-language-e2e-matrix.md` | low | testing, ci, grpc, multi-language | Matrix test for every (client lang) × (server lang) combination; prereq: all gRPC client+server tickets |
-| `go-grpc-client-server.md` | medium | golang, grpc | Implement gRPC service and client; prereq: proto target fix; model after Kotlin |
-| `java-grpc-client-server.md` | medium | java, grpc | Implement gRPC service and client; model after Kotlin |
-| `python-grpc-client-server.md` | medium | python, grpc | Implement gRPC service and client; prereq: proto fix; model after Kotlin |
-| `rust-grpc-client-server.md` | medium | rust, grpc | Add `tonic`; implement gRPC service and client; model after Kotlin |
-| `typescript-grpc-openapi-variant.md` | medium | typescript, grpc, openapi | New language variant: gRPC svc+client (Kotlin-compatible) + OpenAPI REST; dual yarn/npm + Bazel build |
+| File | Area | Summary |
+|---|---|---|
+| `KT-004-kotlin-docker-deployment.md` | kotlin, docker, deployment | Docker container build for Kotlin service; staging + production profiles |
+| `CI-001-github-action-ticket-close-sync.md` | automation, github, tickets | GitHub Action safety net: sync ticket state when issue is closed without a PR ticket update |
+| `BUILD-001-grpc-kotlin-bzlmod-migration.md` | kotlin, bazel, grpc | Migrate to bzlmod-native `grpc_kotlin` when upstream supports it |
+| `GO-002-go-grpc-library-wrong-proto-target.md` | golang, bazel | `go_grpc_library` wraps wrong proto (`//protobuf` → should be `//protobuf:balance_rpc`) |
+| `PY-002-python-proto-integration-incomplete.md` | python, protobuf | Proto import disabled; `foo()` returns `None` |
+| `KT-001-kotlin-grpc-interceptors-not-implemented.md` | kotlin, grpc | `wrapService()` interceptor hook exists but no interceptors implemented |
+| `KT-002-kotlin-dagger-grpc-di.md` | kotlin, grpc, di | Introduce Dagger 2 DI for the Kotlin service via dagger-grpc |
+| `KT-003-kotlin-dagger-client-di.md` | kotlin, grpc, di | Dagger DI for the gRPC client binary; prereq: server DI ticket |
+| `CI-002-cross-language-e2e-matrix.md` | testing, ci, grpc, multi-language | Matrix test for every (client lang) × (server lang) combination; prereq: all gRPC client+server tickets |
+| `GO-001-go-grpc-client-server.md` | golang, grpc | Implement gRPC service and client; prereq: proto target fix; model after Kotlin |
+| `JAVA-001-java-grpc-client-server.md` | java, grpc | Implement gRPC service and client; model after Kotlin |
+| `PY-001-python-grpc-client-server.md` | python, grpc | Implement gRPC service and client; prereq: proto fix; model after Kotlin |
+| `RUST-001-rust-grpc-client-server.md` | rust, grpc | Add `tonic`; implement gRPC service and client; model after Kotlin |
+| `TS-001-typescript-grpc-openapi-variant.md` | typescript, grpc, openapi | New language variant: gRPC svc+client (Kotlin-compatible) + OpenAPI REST; dual yarn/npm + Bazel build |
 
 ---
 

--- a/thoughts/shared/tickets/TS-001-typescript-grpc-openapi-variant.md
+++ b/thoughts/shared/tickets/TS-001-typescript-grpc-openapi-variant.md
@@ -1,8 +1,9 @@
 ---
-date: 2026-03-05
-status: open
-priority: medium
+id: TS-001
+title: Add TypeScript variant with gRPC client/server and OpenAPI REST endpoints
 area: typescript, grpc, openapi, bazel
+status: open
+created: 2026-03-05
 ---
 
 # Feature: Add TypeScript variant with gRPC client/server and OpenAPI REST endpoints


### PR DESCRIPTION
## Prerequisites
- N/A

## Summary
- Add `AGENTS.compressed.md` — token-efficient canonical form of `AGENTS.md`, following the two-form doc convention used across the org
- Add compressed-form redirect block to top of `AGENTS.md`
- Incorporate org-wide rules from `/opt/geekinasuit/agents` bootstrap chain: `§NOINLINE` rule (no non-trivial text inline to shell/tool calls) and the three-level chain (`internal/` → `public/` → `~/.geekinasuit/` fallback)
- Remove content now covered by infrastructure layers (VCS/PR rules, compressed-doc preference rule, basic ticket/plan creation guidance)
- Align ticket conventions to internal agent layer: `see #N` not `fixes #N`; create GitHub issue at start of work; `id/title/area/status/created` frontmatter
- Rename all 14 ticket files from bare `<kebab>.md` to categorical `<PREFIX>-NNN-<kebab>.md`; introduce `OPT` and `AGENT` as defined-but-empty categories
- Update all cross-references in ticket files, plan files, `AGENTS.md`, and `AGENTS.compressed.md`

## Validation performed
- N/A — prose and metadata only

## Affected machines / services
- N/A

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- N/A — no ticket for this work

## Rollback
- `git revert` the squash commit
