### PR TITLE
build: bump dagger-grpc commit to fix internal visibility compile error

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "dagger-grpc", version = "0.1")
 git_override(
     module_name = "dagger-grpc",
     remote = "https://github.com/geekinasuit/dagger-grpc.git",
-    commit = "b5c6206366573f9ae2f654aa9ab090f11a75feda",
+    commit = "728888940ff6f3dec88674230d633739ccc4bd97",
 )
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")


### PR DESCRIPTION
Bump `dagger-grpc` git_override commit to fix a compilation error on main.

The upstream fix makes `Validator.validate()` public, resolving two Kotlin compiler errors in `DaggerGrpcSymbolProcessor.kt`:
- `cannot access '...validate...': it is internal`
- `cannot infer type` for `.map(validator::validate)`

Verified: `bazel test //...` passes (7/7 tests).
