### PR TITLE
docs: unique tmp filenames and cat> for §NOINLINE temp files

### DIFF
--- a/AGENTS.compressed.md
+++ b/AGENTS.compressed.md
@@ -19,9 +19,11 @@ compressed uses §SECTION markers + §ABBREV table at top
 never pass non-trivial text inline to any shell command|tool call
 (backticks,---,* misinterpreted by shell parsers and security hooks)
 always write to file first, then reference by path:
-  gh pr create/edit body → Write tool to /tmp/pr-body.md → --body-file /tmp/pr-body.md
-  gh api comment body → Write tool to /tmp/comment.txt → -F body=@/tmp/comment.txt
-  agent subagent prompts → Write tool to /tmp/prompt.md → Agent prompt: "Read instructions from /tmp/prompt.md"
+  gh pr create/edit body → /tmp/... → --body-file /tmp/...
+  gh api comment body → /tmp/... → -F body=@/tmp/...
+  agent subagent prompts → /tmp/... → Agent prompt: "Read instructions from /tmp/..."
+unique tmp names: include repo+purpose+context (e.g. /tmp/polyglot-pr-body-32.md); never /tmp/pr-body.md — collides across agents
+use cat > (Bash) not Write tool for tmp files: Write errors if file exists without prior read; error can be missed→stale content used
 
 §LAYOUT
 $ts/research/   read before implementing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,9 +29,13 @@ The compressed format uses `§SECTION` markers and an `§ABBREV` table at the to
 Never pass non-trivial text inline to any shell command or tool call. Characters such as backticks, `---`, and `*` are misinterpreted by shell argument parsers and security hooks even when the content is benign.
 
 Always write content to a file first, then reference it by path:
-- `gh pr create/edit` body: Write tool to a temp file (e.g. `/tmp/pr-body.md`), then `--body-file /tmp/pr-body.md`
-- `gh api` comment body: Write tool to a temp file (e.g. `/tmp/comment.txt`), then `-F body=@/tmp/comment.txt`
-- Agent subagent prompts: Write tool to a temp file (e.g. `/tmp/prompt.md`), then in the Agent prompt say "Read your instructions from /tmp/prompt.md and execute them"
+- `gh pr create/edit` body: write to a temp file, then `--body-file /tmp/...`
+- `gh api` comment body: write to a temp file, then `-F body=@/tmp/...`
+- Agent subagent prompts: write to a temp file, then in the Agent prompt say "Read your instructions from /tmp/... and execute them"
+
+**Use unique temp file names** to avoid collisions with other agents running concurrently. Include repo name and purpose (e.g. `/tmp/polyglot-pr-body-32.md`, `/tmp/polyglot-prompt-kt002.md`). Generic names like `/tmp/pr-body.md` will collide.
+
+**Use `cat >` via Bash (not the Write tool) for temp files.** The Write tool requires reading a file before overwriting it if it already exists — a leftover file from a prior agent causes an explicit error that can be missed, leaving stale content in place. `cat >` always overwrites unconditionally.
 
 ---
 


### PR DESCRIPTION
Tightens the §NOINLINE guidance in `AGENTS.md` and `AGENTS.compressed.md` based on a bug observed in practice.

**Problem:** using a generic temp path like `/tmp/pr-body.md` causes stale-content bugs when a prior agent session left a file at the same path. The Write tool also requires reading an existing file before overwriting it — without a prior read, the write errors explicitly, and if that error is missed, the old content gets used.

**Changes:**
- Require unique, repo-scoped temp filenames (e.g. `/tmp/polyglot-pr-body-32.md`)
- Require `cat >` via Bash (not the Write tool) for all temp file writes — unconditional overwrite, no prior-read dependency
