### PR TITLE
tickets: add DB-001, KT-005/006/007 for database capabilities

### DIFF
--- a/thoughts/shared/tickets/DB-001-schema-migrations-setup.md
+++ b/thoughts/shared/tickets/DB-001-schema-migrations-setup.md
@@ -1,0 +1,74 @@
+---
+id: DB-001
+title: Schema migration tooling and initial bracket_pair schema
+area: database, migrations, cross-language
+status: open
+created: 2026-04-21
+---
+
+## Summary
+
+Establish a canonical location for SQL schema files and configure a dual-tool migration strategy: **Flyway** (embedded Java API) for JVM-based implementations, **dbmate** (single static binary, no JVM dependency) for all other languages. Both tools read the same migration files. Down migrations are omitted throughout — they are of dubious value and create cross-tool compatibility issues.
+
+## Current State
+
+No SQL schema files or migration tooling exist. The bracket algorithm hardcodes its pair definitions in Kotlin source.
+
+## Migration File Format
+
+Files use dbmate's `-- migrate:up` marker with no `-- migrate:down` section. This works for both tools:
+
+- **dbmate** treats `-- migrate:up` as a section marker and runs the SQL below it
+- **Flyway** treats `-- migrate:up` as a plain SQL comment, ignores it, and runs the same SQL
+
+Example:
+```sql
+-- migrate:up
+CREATE TABLE bracket_pair (
+    id    INTEGER  PRIMARY KEY,
+    ...
+);
+```
+
+## Filename Convention
+
+dbmate uses `YYYYMMDDHHMMSS_description.sql`; Flyway defaults to `V1__description.sql`. These differ and must be reconciled before finalizing the approach. **Preferred path:** use dbmate's timestamp convention and configure Flyway to match:
+
+```
+flyway.sqlMigrationPrefix=   (empty)
+flyway.sqlMigrationSeparator=_
+```
+
+With this config, Flyway parses `20260421000000_create_bracket_pair.sql` as version `20260421000000`, description `create_bracket_pair`. **This needs to be validated** — if Flyway rejects the timestamp-format version or the single-`_` separator causes problems, fall back to maintaining separate filename sets (same SQL content, different names in a `flyway/` and `dbmate/` subdirectory). Shared content is strongly preferred.
+
+## Schema Constraints
+
+All DDL must stay within SQLite's subset for portability across local (SQLite) and production (PostgreSQL) use:
+- No `RETURNING` clause
+- No stored procedures or triggers
+- No `ADD COLUMN ... AFTER ...` (SQLite ignores column order anyway)
+- Prefer `INTEGER PRIMARY KEY` over `SERIAL` (SQLite auto-increment compatibility)
+
+## Goals / Acceptance Criteria
+
+- [ ] `db/migrations/` directory created at repo root; brief `db/README.md` documents the dual-tool approach and file format conventions
+- [ ] Filename convention validated: dbmate timestamp format confirmed compatible with Flyway (or fallback path documented and implemented)
+- [ ] `20260421000000_create_bracket_pair.sql` (or `V1__...` if fallback) written:
+  - `bracket_pair(id INTEGER PRIMARY KEY, open_char CHAR(1) NOT NULL, close_char CHAR(1) NOT NULL, enabled BOOLEAN NOT NULL DEFAULT TRUE)`
+  - Seed data: the three standard pairs `( )`, `[ ]`, `{ }` all enabled
+  - Uses `-- migrate:up` marker; no `-- migrate:down` section
+- [ ] Migration file validated against SQLite (dbmate or manual) and Flyway (Java API or CLI)
+- [ ] `db/migrations/` exposed as a Bazel `filegroup` so Kotlin and future language targets can declare it as a `data` dependency
+
+## References
+
+- Bracket algorithm: `kotlin/src/main/kotlin/bracketskt/brackets.kt:7`
+- Flyway: https://flywaydb.org — configurable prefix/separator via `FluentConfiguration`
+- dbmate: https://github.com/amacneil/dbmate — single binary, supports SQLite + PostgreSQL
+
+## Notes
+
+Downstream:
+- KT-005 (JOOQ codegen) reads the DDL from this migration via `jooq-meta-extensions` (DDLDatabase) — no live DB needed at build time
+- KT-006 (DB adapter) runs Flyway programmatically on service startup against the configured DataSource
+- Non-JVM language implementations (Go, Python, Rust, TS) run dbmate from CI or a local `make migrate` target

--- a/thoughts/shared/tickets/KT-005-jooq-codegen.md
+++ b/thoughts/shared/tickets/KT-005-jooq-codegen.md
@@ -1,0 +1,41 @@
+---
+id: KT-005
+title: JOOQ integration and DDL-based code generation for Kotlin
+area: kotlin, database, jooq, bazel
+status: open
+created: 2026-04-21
+---
+
+## Summary
+
+Add JOOQ and its Kotlin extensions to the Kotlin build, configure code generation from the Flyway DDL migration files (no live database required at build time), and integrate the codegen step into the Bazel build.
+
+## Current State
+
+No JOOQ dependency exists. DB-001 will provide the schema DDL in `db/migrations/`.
+
+## Prerequisites
+
+- DB-001 (schema DDL must exist before codegen can run)
+
+## Goals / Acceptance Criteria
+
+- [ ] `org.jooq:jooq` and `org.jooq:jooq-kotlin` added to `kotlin/pom.xml` (or Maven central via bzlmod `maven.install`)
+- [ ] JOOQ code generation configured to run from DDL files via `jooq-meta-extensions` (DDLDatabase) — avoids requiring a live DB at build time, which preserves Bazel hermeticity
+- [ ] Generated sources target package: `com.geekinasuit.polyglot.brackets.db.jooq`
+- [ ] Bazel: a genrule or custom rule that runs JOOQ codegen and exposes generated sources as a `kt_jvm_library` target — generated files must be `.gitignore`d (consistent with proto codegen policy)
+- [ ] Codegen produces at minimum: `Tables`, `tables.BracketPair`, `tables.records.BracketPairRecord`
+- [ ] Kotlin extensions (`jooq-kotlin`) usable — coroutine-friendly `fetchOne`, `map` etc.
+- [ ] Bazel build passes (`bazel build //kotlin/...`)
+
+## References
+
+- Schema: `db/migrations/V1__create_bracket_pair.sql` (after DB-001)
+- Proto codegen pattern to follow: `kotlin/BUILD.bazel` — `kt_jvm_proto_library` + generated sources in `_deploy.jar`; same `.gitignore` treatment
+- JOOQ DDL codegen: https://www.jooq.org/doc/latest/manual/code-generation/codegen-ddl/
+- JOOQ Kotlin extensions: https://www.jooq.org/doc/latest/manual/sql-building/kotlin-sql-building/
+
+## Notes
+
+Downstream:
+- KT-007 (configuration feature) uses the generated `BracketPair` table classes

--- a/thoughts/shared/tickets/KT-005-jooq-codegen.md
+++ b/thoughts/shared/tickets/KT-005-jooq-codegen.md
@@ -30,7 +30,7 @@ No JOOQ dependency exists. DB-001 will provide the schema DDL in `db/migrations/
 
 ## References
 
-- Schema: `db/migrations/V1__create_bracket_pair.sql` (after DB-001)
+- Schema: `db/migrations/<migration-file>` — see DB-001 for resolved filename convention (timestamp vs. `V1__` TBD)
 - Proto codegen pattern to follow: `kotlin/BUILD.bazel` — `kt_jvm_proto_library` + generated sources in `_deploy.jar`; same `.gitignore` treatment
 - JOOQ DDL codegen: https://www.jooq.org/doc/latest/manual/code-generation/codegen-ddl/
 - JOOQ Kotlin extensions: https://www.jooq.org/doc/latest/manual/sql-building/kotlin-sql-building/

--- a/thoughts/shared/tickets/KT-006-database-adapter.md
+++ b/thoughts/shared/tickets/KT-006-database-adapter.md
@@ -1,0 +1,51 @@
+---
+id: KT-006
+title: Database adapter layer — DataSource config, connection pool, Flyway, Dagger wiring
+area: kotlin, database, dagger, configuration
+status: open
+created: 2026-04-21
+---
+
+## Summary
+
+Add the runtime database layer to the Kotlin service: a `DatabaseConfig` Hoplite config stanza, a HikariCP `DataSource` factory supporting SQLite (local/test) and PostgreSQL (production), automatic Flyway migration on startup, and a Dagger module that binds `DataSource` and JOOQ `DSLContext` for injection.
+
+## Current State
+
+The service has Hoplite config (ServiceConfig, TelemetryConfig) and a Dagger application graph. No database wiring exists.
+
+## Prerequisites
+
+- DB-001 (migration files needed for Flyway to run)
+- KT-002 (Dagger DI — already resolved)
+
+## Goals / Acceptance Criteria
+
+- [ ] `DatabaseConfig` data class added to `Config.kt` and wired into `ServiceAppConfig`:
+  - `url: String` (JDBC URL; e.g. `jdbc:sqlite::memory:` for dev, `jdbc:postgresql://host/db` for prod)
+  - `driver: String` (defaults: `org.sqlite.JDBC` for sqlite URLs, `org.postgresql.Driver` for pg)
+  - `maxPoolSize: Int = 5`
+- [ ] `service/application.yml` updated with default SQLite in-memory config for local dev
+- [ ] Dependencies added: `com.zaxxer:HikariCP`, `org.xerial:sqlite-jdbc`, `org.postgresql:postgresql`
+- [ ] `DatabaseModule` Dagger module:
+  - Provides `DataSource` (HikariCP pool configured from `DatabaseConfig`)
+  - Provides `DSLContext` (JOOQ, dialect inferred from JDBC URL)
+  - Installed in `ApplicationGraphModule`
+- [ ] Flyway runs on `DataSource` creation (before `DSLContext` is provided) — applies any pending migrations from `db/migrations/`
+- [ ] `db/migrations/` accessible as a Bazel `data` dependency of the service binary
+- [ ] In-memory SQLite used in existing `ApplicationGraphTest` (or a new test component) — no real DB required for tests
+- [ ] SQLite schema constraint noted for implementers: keep DDL within SQLite's subset (no `RETURNING`, limited `ALTER TABLE`)
+- [ ] `bazel test //kotlin/...` passes
+
+## References
+
+- Config types: `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config/Config.kt`
+- Dagger graph: `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/ApplicationGraphModule.kt`
+- Existing test graph: `kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/TestApplicationGraphModule.kt`
+- HikariCP: https://github.com/brettwooldridge/HikariCP
+- JOOQ SQLite dialect: `SQLDialect.SQLITE`
+
+## Notes
+
+Downstream:
+- KT-007 (brackets configuration feature) injects `DSLContext` from this module

--- a/thoughts/shared/tickets/KT-007-bracket-config-feature.md
+++ b/thoughts/shared/tickets/KT-007-bracket-config-feature.md
@@ -1,0 +1,53 @@
+---
+id: KT-007
+title: DB-backed bracket configuration — parameterize algorithm, repository, service integration
+area: kotlin, database, feature
+status: open
+created: 2026-04-21
+---
+
+## Summary
+
+Use the `bracket_pair` table (DB-001) to drive which bracket pairs the service recognizes. This requires: parameterizing the currently hardcoded bracket algorithm, implementing a JOOQ-backed repository that loads enabled pairs from the DB, and injecting that configuration into `BalanceServiceEndpoint`.
+
+## Current State
+
+`brackets.kt` hardcodes `closedParentheses` and `openParentheses` as module-level vals. The service cannot vary bracket pair definitions at runtime.
+
+## Prerequisites
+
+- DB-001 (schema and seed data)
+- KT-005 (JOOQ generated classes)
+- KT-006 (DataSource/DSLContext injectable)
+
+## Goals / Acceptance Criteria
+
+**Algorithm parameterization**
+- [ ] `balancedBrackets(text: String)` gains an overload or parameter: `balancedBrackets(text: String, pairs: Map<Char, Char>)` where `pairs` maps close → open (consistent with existing map direction)
+- [ ] Original zero-argument signature preserved or deprecated-via-default-arg using the existing hardcoded map, so existing tests continue to pass without modification
+
+**Repository**
+- [ ] `BracketPairRepository` class in a new `db` package under the service:
+  - `@Inject constructor(dsl: DSLContext)`
+  - `fun loadEnabledPairs(): Map<Char, Char>` — queries `bracket_pair` where `enabled = true`, maps `close_char → open_char`
+  - Loaded once at `@ApplicationScope` (not per-request) — eager on startup is fine
+- [ ] Dagger binding: `BracketPairRepository` bound at `ApplicationScope`; `Map<Char, Char>` provided from `loadEnabledPairs()` and injected wherever needed
+
+**Service integration**
+- [ ] `BalanceServiceEndpoint` injected with the loaded pair map and passes it to `balancedBrackets`
+- [ ] If no enabled pairs exist in DB, service starts but returns an error response (not a crash)
+
+**Tests**
+- [ ] Unit test for `BracketPairRepository` using in-memory SQLite DSLContext (consistent with KT-006 test pattern)
+- [ ] `BalanceServiceEndpoint` tests updated to supply a known pair map (not DB-dependent)
+- [ ] At least one test verifies that disabling a pair in the test DB causes the algorithm to accept that pair's characters as plain text
+
+**Build**
+- [ ] `bazel test //kotlin/...` passes
+
+## References
+
+- Algorithm: `kotlin/src/main/kotlin/bracketskt/brackets.kt:7-13`
+- Service endpoint: `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BalanceServiceEndpoint.kt`
+- Dagger app scope: `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/ApplicationGraphModule.kt`
+- JOOQ generated tables: `com.geekinasuit.polyglot.brackets.db.jooq.Tables` (after KT-005)

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -38,7 +38,7 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 
 | File | Area | Summary |
 |---|---|---|
-| `DB-001-schema-migrations-setup.md` | database, migrations, cross-language | Flyway migration tooling + `db/migrations/` directory + V1 `bracket_pair` schema |
+| `DB-001-schema-migrations-setup.md` | database, migrations, cross-language | Flyway (JVM) + dbmate (non-JVM) dual-tool migration setup; `db/migrations/`; initial `bracket_pair` schema |
 | `KT-005-jooq-codegen.md` | kotlin, database, jooq, bazel | JOOQ + jooq-kotlin dependency + DDL-based codegen + Bazel genrule; prereq: DB-001 |
 | `KT-006-database-adapter.md` | kotlin, database, dagger, configuration | HikariCP DataSource, Flyway on startup, Dagger DatabaseModule, SQLite/PG support; prereq: DB-001 |
 | `KT-007-bracket-config-feature.md` | kotlin, database, feature | DB-backed bracket pairs: parameterize algorithm + BracketPairRepository + service wiring; prereq: DB-001, KT-005, KT-006 |

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -26,6 +26,7 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 | `PY-NNN` | Python implementation work |
 | `RUST-NNN` | Rust implementation work |
 | `TS-NNN` | TypeScript implementation work |
+| `DB-NNN` | Database schema, migrations, and cross-language DB tooling |
 | `BUILD-NNN` | Build system and tooling (Bazel, bzlmod, rules) |
 | `CI-NNN` | CI, automation, and testing infrastructure |
 | `OPT-NNN` | Performance optimization |
@@ -37,6 +38,10 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 
 | File | Area | Summary |
 |---|---|---|
+| `DB-001-schema-migrations-setup.md` | database, migrations, cross-language | Flyway migration tooling + `db/migrations/` directory + V1 `bracket_pair` schema |
+| `KT-005-jooq-codegen.md` | kotlin, database, jooq, bazel | JOOQ + jooq-kotlin dependency + DDL-based codegen + Bazel genrule; prereq: DB-001 |
+| `KT-006-database-adapter.md` | kotlin, database, dagger, configuration | HikariCP DataSource, Flyway on startup, Dagger DatabaseModule, SQLite/PG support; prereq: DB-001 |
+| `KT-007-bracket-config-feature.md` | kotlin, database, feature | DB-backed bracket pairs: parameterize algorithm + BracketPairRepository + service wiring; prereq: DB-001, KT-005, KT-006 |
 | `KT-004-kotlin-docker-deployment.md` | kotlin, docker, deployment | Docker container build for Kotlin service; staging + production profiles |
 | `CI-001-github-action-ticket-close-sync.md` | automation, github, tickets | GitHub Action safety net: sync ticket state when issue is closed without a PR ticket update |
 | `BUILD-001-grpc-kotlin-bzlmod-migration.md` | kotlin, bazel, grpc | Migrate to bzlmod-native `grpc_kotlin` when upstream supports it |


### PR DESCRIPTION
## Prerequisites
- [ ] N/A

## Summary
- Adds four new tickets for database capabilities in the Kotlin service, plus a new `DB-NNN` ticket category for cross-language database/schema work
- **DB-001**: Schema migration infrastructure — Flyway (JVM, embedded) + dbmate (non-JVM, CLI) dual-tool strategy; shared SQL files using `-- migrate:up` marker with no down sections; initial `bracket_pair` schema with seed data for `()`, `[]`, `{}`
- **KT-005**: JOOQ + jooq-kotlin dependency and DDL-based code generation via `jooq-meta-extensions` (no live DB at build time; preserves Bazel hermeticity)
- **KT-006**: Runtime database adapter — HikariCP DataSource, `DatabaseConfig` Hoplite stanza, Flyway on startup, Dagger `DatabaseModule` binding `DataSource` + `DSLContext`; SQLite in-memory for local/test, PostgreSQL for production
- **KT-007**: DB-backed bracket configuration feature — parameterize `balancedBrackets` algorithm (currently hardcodes pairs), `BracketPairRepository` loading enabled pairs from DB, wired into `BalanceServiceEndpoint`

## Validation performed
- [ ] N/A — prose/tickets only; no code changes

## Affected machines / services
- None — tickets only

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- N/A — this PR *is* the ticket creation

## Rollback
- Revert commit; no runtime impact
