### PR TITLE
docs: add DB feature implementation plan and multi-agent TDD workflow pattern

### DIFF
--- a/thoughts/shared/plans/2026-04-21-db-kotlin-feature.compressed.md
+++ b/thoughts/shared/plans/2026-04-21-db-kotlin-feature.compressed.md
@@ -1,0 +1,257 @@
+<!--COMPRESSED v1; source:2026-04-21-db-kotlin-feature.md-->
+§META
+date:2026-04-21 author:claude tickets:DB-001,KT-005,KT-006,KT-007 status:ready
+
+§ABBREV
+kt=kotlin db=db/migrations mm=MODULE.bazel mig=20260421000000_create_bracket_pair.sql
+arch=2026-04-21-db-feature-architecture
+
+§GOAL
+Replace hardcoded closedParentheses map in brackets.kt with DB-backed config table.
+Stack: JOOQ+HikariCP+Flyway+Dagger; Bazel-hermetic; five single-responsibility PRs.
+
+§CONTEXT
+no DB infra today; brackets.kt has module-level val closedParentheses
+Dagger DI present (KT-002 resolved); ApplicationGraph+ServiceAppConfig = entry points
+maven deps → mm maven.install (no pom.xml)
+dep chain: DB-001 → KT-005||KT-006 (parallel) → KT-007 remainder
+
+§APPROACH
+PR-1(KT-007 partial) ──┐
+PR-2(DB-001)         ──┤─→ PR-3(KT-005) ──┐
+                        └─→ PR-4(KT-006) ──┴─→ PR-5(KT-007 remainder)
+PR-1+PR-2: direct impl (no agent workflow)
+PR-3–PR-5: four-agent workflow (DBA↔Architect[design phase]→TDD Designer→Coder)
+  NOTE this project runs DBA first (schema is primary driver); general pattern is Architect-led round-trip
+
+§CONSTRAINTS
+DDL must satisfy THREE parsers:
+  SQLite(runtime local/test) | PostgreSQL(runtime prod) | H2(build-time; DDLDatabase uses H2)
+safe: INTEGER PRIMARY KEY; CHAR(1); BOOLEAN NOT NULL DEFAULT TRUE
+avoid: RETURNING; SERIAL; stored procs; ADD COLUMN...AFTER; GENERATED ALWAYS
+
+§AGENTS
+
+WORKFLOW SEQUENCE (PRs 3–5):
+  1. DBA + Architect [collaborative; this project runs DBA first as exception — schema is primary driver]
+       DBA → db-schema-design.md; Architect [reads DBA output] → $arch.md
+  2. For each PR(3,4,5) in order:
+       a. TDD Designer → designs types+interfaces+APIs; writes tests (red); consults DBA(data)|Architect(strategic tensions)
+       b. Coder → fills in bodies to make tests pass; consults DBA(data)|Architect(API conflicts)
+       c. Coordinator breaks deadlocks if DBA+Architect can't resolve
+
+AGENT RULES:
+  DBA: authority on schema, migrations, seeding, DB portability; all data questions route here first
+  Architect: authority on strategic API shape, Dagger graph, long-term fit; escalate strategic tensions (not every tactical choice)
+  TDD Designer: translates Architect's strategic constraints into concrete types+interfaces+APIs via tests
+    design authority over tactical details Architect left open; tests compile+fail; no impl bodies
+    Coder must not change TDD Designer's type/interface/method contracts without TDD Designer agreement; escalate to Architect if unresolved
+  Coder: full latitude on private impl (private types, fns, names, helpers); NO unilateral public shape changes;
+    negotiate public changes with TDD Designer first, then Architect; ktfmt all .kt
+  Coordinator: breaks deadlocks only — after both DBA+Architect consulted
+
+CONSTRAINTS BY ROLE:
+  DBA + Architect:
+    compressed-format: read /opt/geekinasuit/agents/internal/workflows/compressed-format.compressed.md
+      applies to .md output docs only — .sql and other non-prose files have NO compressed form
+      must produce both .md + .compressed.md for research output doc
+    shell-safety: never inline non-trivial text in shell cmds; write to /tmp/polyglot-<purpose>-<ctx>.txt first
+  TDD Designer + Coder:
+    VCS: jj only; never run git
+    build: bazel (not bazelisk)
+    style: ktfmt all modified .kt files before work is done
+    shell-safety: same as above
+
+DBA PROMPT:
+  Constraints: compressed-format + shell-safety (see above)
+  Read first:
+    thoughts/shared/tickets/DB-001-schema-migrations-setup.md
+    thoughts/shared/tickets/KT-006-database-adapter.md
+    thoughts/shared/tickets/KT-007-bracket-config-feature.md
+    thoughts/shared/plans/2026-04-21-db-kotlin-feature.md
+  Role: DBA + data architect. Design schema, migrations, seeding, tooling.
+  Design and document:
+    1. Schema: finalize bracket_pair DDL; verify portability across SQLite/PostgreSQL/H2;
+       rationale for each column type/constraint
+    2. Migration filename convention: validate Flyway empty-prefix+single-_ approach;
+       produce validated conclusion (works or fallback) with evidence
+    3. Seed data strategy: INSERT in migration vs. separate mechanism;
+       can tests reset/override seed data cleanly with in-memory SQLite?
+    4. Future schema evolution: what changes are plausible? does initial schema foreclose any?
+       don't over-engineer — just avoid unnecessary dead ends
+    5. dbmate compatibility: confirm -- migrate:up (no down) works for both tools on same file
+    6. Test data strategy: in-memory SQLite per test; schema+seed via Flyway; no shared state
+    7. Bazel filegroup: //db:migrations glob sufficient? any edge cases?
+  Output: thoughts/shared/research/2026-04-21-db-schema-design.md + .compressed.md
+  Mark each decision: fixed (others must not deviate) | provisional (open to Architect/impl refinement)
+
+ARCHITECT PROMPT:
+  Constraints: compressed-format + shell-safety (see above)
+  Read first:
+    thoughts/shared/research/2026-04-21-db-schema-design.md [DBA output — read this first]
+    thoughts/shared/plans/2026-04-21-db-kotlin-feature.md
+    thoughts/shared/tickets/KT-005,KT-006,KT-007
+    kotlin/src/main/kotlin/bracketskt/brackets.kt
+    kotlin/src/main/kotlin/.../service/BalanceServiceEndpoint.kt
+    kotlin/src/main/kotlin/.../service/dagger/ApplicationGraph.kt
+    kotlin/src/main/kotlin/.../service/dagger/ApplicationGraphModule.kt
+    kotlin/src/main/kotlin/.../service/dagger/GrpcHandlersModule.kt
+    kotlin/src/main/kotlin/.../config/Config.kt
+    kotlin/src/test/kotlin/.../service/dagger/ApplicationGraphTest.kt
+    kotlin/src/test/kotlin/.../service/dagger/TestApplicationGraphModule.kt
+    kotlin/src/test/kotlin/.../service/dagger/TestApplicationGraph.kt
+  Role: architect for PRs 3–5. CRC-card level or coarser — subsystems, responsibilities,
+    high-level collaborations, flow. Set constraints+intent; TDD Designer fills tactical details.
+  Design and document (with rationale):
+    1. Layer boundaries: which layers(DB adapter/repository/service); responsibilities of each;
+       what collaborates with what; should BalanceServiceEndpoint depend on narrow abstraction? (testability arg)
+       describe at responsibility level — TDD Designer names interfaces+defines sigs
+    2. Dagger module decomposition: name modules+responsibilities; can DataSource/Flyway/DSLContext
+       be overridden independently in tests? how does DatabaseConfig flow into graph?
+       describe topology — TDD Designer defines exact provider sigs
+    3. Repository responsibility: what is it for? interface separating from consumers? why?
+       what changes if JOOQ→JDBC or async? describe boundary so changes don't propagate to service layer
+    4. Startup/lifecycle: when Flyway runs; who ensures migrations applied before DSLContext used
+    5. Coroutine readiness: JOOQ blocking; describe how repository boundary contains future async migration
+    6. Test surfaces per layer: unit vs integration; kinds of doubles needed; test Dagger modules
+       keep at "fake in-memory impl of repository interface" level — TDD Designer writes the actual fake
+    7. Explicitly deferred: list what TDD Designer decides; flag what must be settled now vs. later
+  Output: thoughts/shared/research/$arch.md + .compressed.md
+  Write at responsibility+constraint level — NOT method-signature level
+  Mark fixed (TDD Designer must not deviate) vs. open (TDD Designer's domain)
+
+TDD-DESIGNER PROMPT:
+  Constraints: VCS(jj) + build(bazel) + ktfmt + shell-safety (see above)
+  Read first:
+    thoughts/shared/research/$arch.md [primary constraint — not a script; strategic boundaries only]
+    thoughts/shared/research/2026-04-21-db-schema-design.md [DBA output]
+    thoughts/shared/plans/2026-04-21-db-kotlin-feature.md
+    kotlin/src/test/kotlin/bracketskt/BracketsTest.kt
+    kotlin/src/test/kotlin/.../service/dagger/ApplicationGraphTest.kt
+    kotlin/src/test/kotlin/.../service/dagger/TestApplicationGraphModule.kt
+    kotlin/src/test/kotlin/.../service/dagger/BUILD.bazel
+    kotlin/src/test/kotlin/.../service/dagger/FakeTelemetryModule.kt
+  Role: TDD Designer for PRs 3–5. Tactical designer working test-first.
+    Architect sets strategic boundaries; you fill the tactical space:
+      interface names, method signatures, error contracts, type shapes, test doubles
+    Your type/interface definitions are design output — not placeholders for Coder to rethink
+  Design principles:
+    prefer narrow interfaces; prefer value types (data class, sealed) over primitives at boundaries
+    fakes over mocks; JUnit 4 + Truth; tests compile+fail before Coder starts
+    where Architect left decisions open → make them yourself; document rationale in comments
+    genuine strategic tensions (not tactical gaps) → escalate to Architect before committing
+  Placement: interfaces+types in kotlin/src/main/kotlin/...; tests+fakes in kotlin/src/test/kotlin/...
+    kt_jvm_test targets in BUILD.bazel per existing patterns
+  Cover:
+    Repository contract: enabled pairs loaded; disabled ignored; empty→no crash; close→open direction
+    Service layer: known pairs→correct result(no DB); empty→error response; unbalanced→correct error; unknown chars=plain text
+    Dagger wiring: test graph with in-memory SQLite; repository injectable; disable-pair end-to-end
+  When done: tell Coder — files written; interfaces+types defined; TODO() bodies for them to fill;
+    decisions that extend/deviate from Architect doc (so Coder understands full contract)
+  Coder must not change your type/interface/sig definitions without your agreement; escalate to Architect if unresolved
+
+CODER PROMPT:
+  Constraints: VCS(jj) + build(bazel) + ktfmt + shell-safety (see above)
+  Read first:
+    thoughts/shared/research/$arch.md [primary reference]
+    thoughts/shared/research/2026-04-21-db-schema-design.md [DBA output]
+    thoughts/shared/plans/2026-04-21-db-kotlin-feature.md
+    all type+interface+test files from TDD Designer (they will list these)
+    kotlin/src/main/kotlin/bracketskt/brackets.kt
+    kotlin/src/main/kotlin/.../service/BalanceServiceEndpoint.kt
+    kotlin/src/main/kotlin/.../service/dagger/ApplicationGraph.kt
+    kotlin/src/main/kotlin/.../config/Config.kt
+    kotlin/src/main/kotlin/.../service/BUILD.bazel
+    kotlin/BUILD.bazel; MODULE.bazel
+  Role: Coder for PRs 3–5. TDD Designer has laid out the skeleton (interfaces, class declarations,
+    module structure, TODO() stubs). Public contract is decided.
+    Below the public surface: full creative latitude — private types, private functions, local names,
+    internal helpers, utility extraction, internal state structure, lib call choices. Create freely.
+  Rules:
+    may PROPOSE public shape changes (implementation insight often reveals gaps) — collaborative request to TDD Designer, not unilateral edit
+    TDD Designer agrees → make change; disagree → escalate to Architect
+    impossible test = reason to propose a change; bring to TDD Designer with explanation; never silent change
+    Bazel: kt_jvm_library; java_binary+runtime_deps; associates=[...]; new deps → mm maven.install
+    H2 NOT in service runtime_deps (build-time only)
+    Flyway: filesystem: location + RUNFILES_DIR resolution (see plan PR-4)
+    JOOQ genrule outs: exhaustive; run codegen locally once first to discover all files
+  Per PR(3,4,5 in order): read design docs+tests → implement → bazel test //kotlin/... passes → ktfmt → report deviations
+  Deadlock: bring conflict to DBA(data)|Architect(API); Coordinator breaks if unresolved
+
+§STEPS
+
+PR-1 KT-007(partial) branch:kt-007-algorithm-param prereqs:NONE agents:direct
+  fun balancedBrackets(text:String, pairs:Map<Char,Char>=closedParentheses)
+    replace internal refs to closedParentheses/openParentheses with pairs/opens
+  no new deps; no Bazel targets; no config changes; existing BracketsTest passes unchanged
+  accept: bazel test //kotlin/... passes
+
+PR-2 DB-001 branch:db-001-schema-migrations prereqs:NONE agents:direct
+  1. create db/migrations/
+  2. validate Flyway filename convention (sqlMigrationPrefix="" sqlMigrationSeparator="_")
+       fallback if rejected: flyway/V1__... + dbmate/20260421000000_...(same SQL)
+  3. write $mig: CREATE TABLE bracket_pair(id,open_char,close_char,enabled) + 3 seed INSERTs
+  4. db/README.md: dual-tool; format; filename convention; portability constraints
+  5. db/BUILD.bazel filegroup(migrations)
+  6. validate with dbmate
+  accept: //db:migrations defined; validated; README written
+
+PRE-PR-3: design phase [DBA first in this project; Architect reads DBA output; see workflow note]
+           DBA → thoughts/shared/research/2026-04-21-db-schema-design.md
+           Architect → thoughts/shared/research/$arch.md
+           both reviewed by coordinator before PR-3 starts
+
+PR-3 KT-005 branch:kt-005-jooq-codegen prereq:DB-001 agents:TDD Designer→Coder [consult DBA+Architect]
+  new mm: org.jooq:jooq:3.19.x; jooq-kotlin:3.19.x; jooq-meta-extensions:3.19.x[codegen];
+          jooq-codegen:3.19.x[codegen]; com.h2database:h2:2.x.x[build-time only]
+  codegen runner: JooqCodegenRunner(DDL path, out dir) → GenerationTool.generate()
+    Database=DDLDatabase; pkg=com.geekinasuit.polyglot.brackets.db.jooq
+  Bazel: java_binary(jooq_codegen_runner) → genrule(jooq_generated_srcs;outs exhaustive) →
+         kt_jvm_library(jooq_db_lib;visibility=public)
+  codegen→Java(.java) not Kotlin; jooq-kotlin=runtime only; outs must be exhaustive; .gitignored
+  accept: bazel build //kotlin/... passes; Tables/BracketPair/BracketPairRecord available
+
+PR-4 KT-006 branch:kt-006-database-adapter prereq:DB-001 [parallel with PR-3] agents:TDD Designer→Coder [consult DBA+Architect]
+  new mm: HikariCP:5.x.x; sqlite-jdbc:3.x.x; postgresql:42.x.x;
+          flyway-core:10.x.x; flyway-database-sqlite:10.x.x
+  Config.kt: DatabaseConfig(url,driver,maxPoolSize=5); wire into ServiceAppConfig
+  service/application.yml: database.url=jdbc:sqlite::memory:
+  DatabaseModule: dataSource(config)→HikariCP+Flyway; dslContext(ds,config)→dialect from url
+  FLYWAY GOTCHA: filesystem: location; Paths.get(RUNFILES_DIR?:".", "_main/db/migrations")
+  wire DatabaseModule into ApplicationGraph
+  Bazel: //db:migrations → data= of brackets_service; runtime deps in service BUILD.bazel
+  tests: TestApplicationGraph with in-memory SQLite; existing tests pass
+  accept: bazel test //kotlin/... passes; Flyway runs on startup
+
+PR-5 KT-007(remainder) branch:kt-007-bracket-config prereqs:PR-1+KT-005+KT-006 agents:TDD Designer→Coder [consult DBA+Architect]
+  new pkg com.geekinasuit.polyglot.brackets.db:
+    BracketPairRepository @ApplicationScope @Inject(dsl:DSLContext)
+      loadEnabledPairs():Map<Char,Char> — SELECT enabled=true; map close_char→open_char
+  Dagger: BracketConfigModule provides Map<Char,Char> @ApplicationScope from repo.loadEnabledPairs()
+  BalanceServiceEndpoint: inject Map<Char,Char>; pass to balancedBrackets; empty→error response
+  tests:
+    BracketPairRepositoryTest: in-memory SQLite; migration; assert loadEnabledPairs
+    BalanceServiceEndpointTest: known pair map; no DB
+    disable-pair test: () disabled→treated as plain text
+    ApplicationGraphTest: DatabaseConfig in-memory SQLite; full graph builds
+  Bazel: kt_jvm_library for db pkg; add to service_lib deps
+  accept: bazel test //kotlin/... passes; disable-pair test passes
+
+§RISKS
+| Risk | Mitigation |
+|---|---|
+| Flyway rejects empty-prefix+single-_ | DBA validates; fallback documented |
+| genrule outs must be exhaustive | Coder runs codegen locally once first |
+| Flyway classpath vs runfiles | filesystem: + RUNFILES_DIR (see PR-4) |
+| H2 DDL compat | DBA verifies DDL against H2; safe subset only |
+| Dagger raw Map<Char,Char> binding | Architect decides: @Named or wrapper type |
+| Agent deadlock | Escalate to DBA|Architect first; Coordinator breaks if unresolved |
+
+§DONE
+- [ ] PR-1: balancedBrackets(text,pairs=default); existing tests pass unchanged
+- [ ] DBA doc: thoughts/shared/research/2026-04-21-db-schema-design.md exists+reviewed
+- [ ] Architect doc: thoughts/shared/research/$arch.md exists+reviewed
+- [ ] PR-2: db/migrations/ + validated migration + //db:migrations + README
+- [ ] PR-3: JOOQ genrule → Tables/BracketPair/BracketPairRecord; .gitignored; bazel build passes
+- [ ] PR-4: DatabaseConfig+yml; DatabaseModule+Flyway; bazel test passes
+- [ ] PR-5: BracketPairRepository; BalanceServiceEndpoint uses injected map; all tests pass; bazel test //kotlin/... passes

--- a/thoughts/shared/plans/2026-04-21-db-kotlin-feature.md
+++ b/thoughts/shared/plans/2026-04-21-db-kotlin-feature.md
@@ -511,7 +511,7 @@ session coordinator (the human or coordinating agent).
 
 **Branch:** `kt-005-jooq-codegen`  
 **Prereq:** DB-001 merged  
-**Agents:** Tester then Coder (see prompts above); Architect available for consultation
+**Agents:** TDD Designer then Coder (see prompts above); Architect available for consultation
 
 **New maven artifacts in `MODULE.bazel`:**
 - `org.jooq:jooq:3.19.x` (latest stable)
@@ -580,7 +580,7 @@ kt_jvm_library(
 
 **Branch:** `kt-006-database-adapter`  
 **Prereq:** DB-001 merged (KT-005 not required — can be prepared in parallel with PR 3)  
-**Agents:** Tester then Coder (see prompts above); Architect available for consultation
+**Agents:** TDD Designer then Coder (see prompts above); Architect available for consultation
 
 **New maven artifacts in `MODULE.bazel`:**
 - `com.zaxxer:HikariCP:5.x.x`
@@ -683,7 +683,7 @@ on startup; in-memory SQLite works in tests.
 
 **Branch:** `kt-007-bracket-config`  
 **Prereqs:** PR 1 (algorithm param), KT-005, KT-006 all merged  
-**Agents:** Tester then Coder (see prompts above); Architect available for consultation
+**Agents:** TDD Designer then Coder (see prompts above); Architect available for consultation
 
 **`BracketPairRepository`** in new package `com.geekinasuit.polyglot.brackets.db`
 (exact interface shape from Architect design doc):
@@ -754,7 +754,7 @@ disabling a pair in the test DB causes the algorithm to treat those characters a
 | Flyway classpath scan misses Bazel runfiles | Use `filesystem:` location with `RUNFILES_DIR` resolution (see PR 4 detail) |
 | H2 DDL compatibility | Stick to safe subset; test locally |
 | Dagger raw `Map<Char, Char>` binding collision | Use `@Named` qualifier or a wrapper type if Dagger complains |
-| Architect/Tester/Coder deadlock | Coordinator breaks deadlock; Architect is authority on API shape |
+| Architect/TDD Designer/Coder deadlock | Coordinator breaks deadlock; Architect is authority on API shape |
 
 ---
 

--- a/thoughts/shared/plans/2026-04-21-db-kotlin-feature.md
+++ b/thoughts/shared/plans/2026-04-21-db-kotlin-feature.md
@@ -761,6 +761,7 @@ disabling a pair in the test DB causes the algorithm to treat those characters a
 ## Acceptance Criteria (Summary)
 
 - [ ] PR 1: `balancedBrackets` accepts optional pair map; all existing tests pass unchanged
+- [ ] DBA doc: `thoughts/shared/research/2026-04-21-db-schema-design.md` exists and reviewed
 - [ ] Architect doc: `thoughts/shared/research/2026-04-21-db-feature-architecture.md` exists and reviewed
 - [ ] PR 2: `db/migrations/` + validated migration file + `//db:migrations` filegroup + `db/README.md`
 - [ ] PR 3: JOOQ genrule produces `Tables`, `BracketPair`, `BracketPairRecord`; `.gitignore`d; `bazel build` passes

--- a/thoughts/shared/plans/2026-04-21-db-kotlin-feature.md
+++ b/thoughts/shared/plans/2026-04-21-db-kotlin-feature.md
@@ -522,11 +522,11 @@ session coordinator (the human or coordinating agent).
 
 **Codegen runner:**
 
-Write a small Java/Kotlin main class (e.g. `JooqCodegenRunner`) that takes the DDL file
-path and output directory as CLI arguments, then calls `GenerationTool.generate(...)`
-programmatically with:
+Write a small Java/Kotlin main class (e.g. `JooqCodegenRunner`) that takes one or more DDL
+file paths followed by an output directory as CLI arguments (i.e. `<ddl-file>... <output-dir>`),
+then calls `GenerationTool.generate(...)` programmatically with:
 - `Database`: `org.jooq.meta.extensions.ddl.DDLDatabase`
-- Input schema: the DDL path arg
+- Input schema: all DDL path args (semicolon-separated) — `$(locations //db:migrations)` expands to all `.sql` files space-separated; runner treats all args except the last as DDL inputs, last arg as output dir; files processed in Bazel expansion order (lexicographic = migration order)
 - Target package: `com.geekinasuit.polyglot.brackets.db.jooq`
 - Target directory: the output dir arg
 

--- a/thoughts/shared/plans/2026-04-21-db-kotlin-feature.md
+++ b/thoughts/shared/plans/2026-04-21-db-kotlin-feature.md
@@ -1,0 +1,768 @@
+---
+date: 2026-04-21
+author: claude
+tickets: DB-001, KT-005, KT-006, KT-007
+status: ready
+---
+
+# Plan: DB-backed Bracket Configuration (Kotlin)
+
+Covers the full DB implementation chain: migration tooling (DB-001), JOOQ codegen (KT-005),
+database adapter and Dagger wiring (KT-006), and the bracket configuration feature (KT-007).
+
+---
+
+## Goal
+
+Replace the hardcoded `closedParentheses` map in `brackets.kt` with a database-backed
+configuration table, using idiomatic Kotlin + JOOQ + HikariCP + Flyway, wired via Dagger,
+all built hermetically with Bazel.
+
+---
+
+## Context
+
+- No DB infrastructure exists today; bracket pairs are module-level `val`s in `brackets.kt`
+- Dagger DI is already present (KT-002 resolved); `ApplicationGraph` + `ServiceAppConfig` are the entry points
+- Maven deps go in `MODULE.bazel` `maven.install` artifacts list (no `pom.xml`)
+- The four tickets have a strict dependency chain: DB-001 → KT-005 and KT-006 (parallel) → KT-007
+
+---
+
+## Approach
+
+Five single-responsibility PRs. KT-007's algorithm parameterization is split out as PR 1
+because it has no DB dependency and can land independently. DB-001 is PR 2. KT-005 and
+KT-006 can be prepared in parallel once DB-001 merges. KT-007's repository and service
+wiring land last as PR 5.
+
+```
+PR 1 (KT-007 partial)  ──┐
+PR 2 (DB-001)          ──┤─→ PR 3 (KT-005) ──┐
+                          └─→ PR 4 (KT-006) ──┴─→ PR 5 (KT-007 remainder)
+```
+
+PRs 1 and 2 are simple enough to implement directly. PRs 3–5 use a structured
+four-agent workflow described below.
+
+### DDL / schema constraints
+
+All DDL must be compatible with three parsers:
+- **SQLite** — runtime (local dev, tests)
+- **PostgreSQL** — runtime (production)
+- **H2** — build time only (JOOQ DDLDatabase uses H2 to parse DDL during codegen)
+
+`INTEGER PRIMARY KEY`, `CHAR(1)`, `BOOLEAN NOT NULL DEFAULT TRUE` are safe across all three.
+Avoid: `RETURNING`, `SERIAL`, stored procedures, `ADD COLUMN ... AFTER`, `GENERATED ALWAYS`.
+
+---
+
+## Agent Workflow (PRs 3–5)
+
+PRs 3–5 are implemented using a four-agent structure: a DBA who designs the schema and
+data infrastructure, an Architect who designs the Kotlin API surfaces and Dagger graph on
+top of that, a TDD Designer who writes tests against those surfaces (test-first), and a Coder
+who implements code to make the tests pass. The coordinating agent (the session running
+these subagents) breaks deadlocks.
+
+### Workflow sequence
+
+```
+1. DBA agent + Architect agent — collaborative design phase (see note below)
+     produces: schema design doc (DBA) + API/Dagger design doc (Architect)
+2. For each PR (3, 4, 5), in order:
+     a. TDD Designer reads both design docs → designs types/interfaces/APIs → writes tests (red)
+     b. Coder reads both design docs + TDD Designer files → implements (green)
+     c. Both consult DBA (data questions) or Architect (API questions) for ambiguities
+     d. Coordinator breaks any deadlock
+```
+
+**Note on Phase 1 sequencing for this project:** In general the Architect drives the need
+and the DBA negotiates the schema to serve it — a round-trip, not a handoff. Here the
+sequencing is reversed (DBA first, then Architect) because we are retrofitting a DB
+requirement onto an existing application where the schema is the primary new driver.
+This is the exception; in a greenfield feature the Architect would run first.
+
+### Rules
+
+- **DBA** is the authority on schema, migration tooling, seeding, and DB portability.
+  Architect, TDD Designer, and Coder escalate all data/schema questions here first.
+- **Architect** is the authority on strategic API shape, Dagger module structure, and
+  long-term fit. TDD Designer and Coder escalate decisions that might conflict with
+  strategic intent — not every tactical choice, only genuine tensions.
+- **TDD Designer** translates the Architect's strategic constraints into concrete types,
+  interfaces, and APIs — then expresses those decisions as tests. Has full design authority
+  over tactical details the Architect left open. Tests must compile and fail before the
+  Coder touches anything.
+- **Coder** has full creative latitude in the private implementation space: private types,
+  private functions, local names, internal helpers, utility extraction. May propose changes
+  to the public contract — implementation insight often reveals things the designer couldn't
+  anticipate — but as a collaborative request to the TDD Designer, not a unilateral edit.
+  TDD Designer agrees → proceed. Disagree → escalate to Architect.
+- **Coordinator** resolves genuine deadlocks only — after DBA and Architect have both
+  been consulted and the impasse remains.
+
+---
+
+### DBA Agent Prompt
+
+> **Constraints (apply before doing any other work):**
+> - **Compressed format:** Read `/opt/geekinasuit/agents/internal/workflows/compressed-format.compressed.md`
+>   for the conventions you must follow when producing `.compressed.md` companion files. This
+>   applies to your Markdown output documents only — `.sql` files and other non-prose assets
+>   have no compressed form. You must produce both `.md` and `.compressed.md` for your research doc.
+> - **Shell safety:** Never pass non-trivial text inline to shell commands — backticks, `---`, and
+>   `*` get misinterpreted by shell parsers and security hooks. Write content to a temp file first,
+>   then reference by path. Use unique names: `/tmp/polyglot-<purpose>-<context>.txt`.
+>
+> **Read these files before doing any design work:**
+>
+> - `thoughts/shared/plans/2026-04-21-db-kotlin-feature.md` — the full implementation plan
+> - `thoughts/shared/tickets/DB-001-schema-migrations-setup.md`
+> - `thoughts/shared/tickets/KT-006-database-adapter.md`
+> - `thoughts/shared/tickets/KT-007-bracket-config-feature.md`
+>
+> **Your role:** You are the DBA and data architect for the DB feature. Your domain covers schema
+> design, migration tooling, seeding, and test data strategy. The Architect agent will read your
+> output and build the Kotlin API design on top of it — so be precise about anything that
+> constrains the application layer (e.g. column types, nullability, indexing decisions,
+> migration sequencing).
+>
+> **Design and document the following, with rationale for each decision:**
+>
+> 1. **Schema:** Finalize the `bracket_pair` DDL. Verify each column type and constraint is
+>    portable across SQLite (runtime), PostgreSQL (runtime), and H2 (build-time, used by JOOQ
+>    DDLDatabase). Document why each choice is safe across all three.
+>
+> 2. **Migration filename convention:** Validate whether Flyway accepts dbmate-style timestamp
+>    filenames (`20260421000000_create_bracket_pair.sql`) when configured with
+>    `sqlMigrationPrefix=""` and `sqlMigrationSeparator="_"`. Produce a validated conclusion
+>    with evidence. If it fails, document the fallback (separate `flyway/` and `dbmate/`
+>    subdirectories, same SQL content, different names) and why.
+>
+> 3. **Seed data strategy:** Should the three standard pairs be inserted in the migration file
+>    itself, or via a separate seed mechanism? Consider: can tests reset or override seed data
+>    cleanly with an in-memory SQLite DB? What are the tradeoffs for reproducibility?
+>
+> 4. **Future schema evolution:** What changes to `bracket_pair` are plausible over time
+>    (ordering, categories, locale, per-user config)? Note what the current schema would need
+>    to add to support each, and confirm the initial design does not foreclose reasonable paths.
+>    Do not over-engineer — just avoid unnecessary dead ends.
+>
+> 5. **dbmate compatibility:** Confirm the `-- migrate:up` marker (with no `-- migrate:down`
+>    section) works correctly for both dbmate and Flyway on the same file.
+>
+> 6. **Test data strategy:** How do integration tests get a clean, reproducible DB state?
+>    Propose the pattern (e.g. in-memory SQLite per test class, schema applied via Flyway,
+>    seed data inserted in test setup). No shared mutable state between tests.
+>
+> 7. **Bazel filegroup:** Confirm `//db:migrations` with `glob(["migrations/*.sql"])` is
+>    sufficient. Note any edge cases (e.g. ordering, subdirectory layout).
+>
+> **Output:** Write your findings to:
+> `thoughts/shared/research/2026-04-21-db-schema-design.md`
+>
+> Also produce a compressed companion:
+> `thoughts/shared/research/2026-04-21-db-schema-design.compressed.md`
+>
+> Mark each decision as **fixed** (Architect and implementers must not deviate) or
+> **provisional** (open to refinement by the Architect or implementers with good reason).
+
+---
+
+### Architect Agent Prompt
+
+> **Constraints (apply before doing any other work):**
+> - **Compressed format:** Read `/opt/geekinasuit/agents/internal/workflows/compressed-format.compressed.md`
+>   for the conventions you must follow when producing `.compressed.md` companion files. You must
+>   produce both `.md` and `.compressed.md` forms for your output document.
+> - **Shell safety:** Never pass non-trivial text inline to shell commands — backticks, `---`, and
+>   `*` get misinterpreted by shell parsers and security hooks. Write content to a temp file first,
+>   then reference by path. Use unique names: `/tmp/polyglot-<purpose>-<context>.txt`.
+>
+> **Read these files before doing any design work:**
+>
+> - `thoughts/shared/research/2026-04-21-db-schema-design.md` — DBA output; read this first
+> - `thoughts/shared/plans/2026-04-21-db-kotlin-feature.md` — the full implementation plan
+> - `thoughts/shared/tickets/KT-005-jooq-codegen.md`
+> - `thoughts/shared/tickets/KT-006-database-adapter.md`
+> - `thoughts/shared/tickets/KT-007-bracket-config-feature.md`
+> - `kotlin/src/main/kotlin/bracketskt/brackets.kt`
+> - `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BalanceServiceEndpoint.kt`
+> - `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/ApplicationGraph.kt`
+> - `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/ApplicationGraphModule.kt`
+> - `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/GrpcHandlersModule.kt`
+> - `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config/Config.kt`
+> - `kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/ApplicationGraphTest.kt`
+> - `kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/TestApplicationGraphModule.kt`
+> - `kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/TestApplicationGraph.kt`
+>
+> **Your role:** You are the Architect for the database feature (PRs 3–5). Your job is to
+> design the structure of the Kotlin implementation at a CRC-card level or coarser —
+> subsystems, responsibilities, high-level collaborations and flow. You work from the DBA's
+> schema design and the existing codebase. The TDD Designer will fill in the tactical details
+> (exact method signatures, error contracts, type names) within the boundaries you establish.
+> You are setting constraints and intent, not writing a complete spec.
+>
+> **Design and document the following, with rationale for each decision:**
+>
+> 1. **Layer boundaries.** Which layers exist (DB adapter, repository, service)? What are
+>    the responsibilities of each? What collaborates with what? Should `BalanceServiceEndpoint`
+>    depend on a repository abstraction or something narrower — and what is the testability
+>    argument for your choice? Describe at responsibility level; the TDD Designer will name
+>    the interfaces and define the signatures.
+>
+> 2. **Dagger module decomposition.** Name the modules and describe what each is responsible
+>    for providing. Consider: should `DataSource`, Flyway lifecycle, and `DSLContext` be
+>    separate providers so tests can override individual pieces? How does `DatabaseConfig`
+>    flow from `ServiceAppConfig` into the graph? Describe the topology; the TDD Designer
+>    will define the exact provider signatures.
+>
+> 3. **Repository responsibility.** What is the repository responsible for, and what does it
+>    collaborate with? Should there be an interface separating the repository from its
+>    consumers — and why? Consider: what would change if JOOQ were swapped for raw JDBC, or
+>    if the repository became async? Design the responsibility boundary so those changes
+>    don't propagate into the service layer.
+>
+> 4. **Startup and lifecycle.** When does Flyway run? Who is responsible for ensuring
+>    migrations are applied before the `DSLContext` is used? Describe the sequencing
+>    as Dagger sees it.
+>
+> 5. **Coroutine readiness.** JOOQ is blocking. The service uses `StreamObserver` callbacks,
+>    not coroutines. Describe how the repository responsibility boundary should be drawn so
+>    a future async migration is contained there and does not ripple into callers.
+>
+> 6. **Test surfaces.** For each layer, describe: what is tested at unit vs. integration
+>    level? What kinds of test doubles are needed? Which Dagger modules would a test graph
+>    replace? Keep at the level of "a fake in-memory implementation of the repository
+>    interface" — the TDD Designer will write the actual fake.
+>
+> 7. **Explicitly deferred decisions.** List what you are deliberately leaving open for the
+>    TDD Designer. This is not a weakness — it is the handoff boundary. Be clear about which
+>    decisions must be made now to avoid expensive rework, and which can be made later.
+>
+> **Output:** Write your findings to:
+> `thoughts/shared/research/2026-04-21-db-feature-architecture.md`
+>
+> Also produce a compressed companion:
+> `thoughts/shared/research/2026-04-21-db-feature-architecture.compressed.md`
+>
+> The design doc is the primary reference for the TDD Designer and Coder. Write at
+> responsibility and constraint level — not at method-signature level. Be explicit about
+> what is fixed (TDD Designer must not deviate) versus what is deliberately open
+> (TDD Designer's domain to decide).
+
+---
+
+### TDD Designer Agent Prompt
+
+> **Constraints (apply before doing any other work):**
+> - **VCS:** This repo uses `jj` (jujutsu). Never run `git` commands.
+> - **Build:** Use `bazel` (not `bazelisk`) for all build and test commands.
+> - **Style:** Run `ktfmt` on every `.kt` file you write or modify before considering your work done.
+> - **Shell safety:** Never pass non-trivial text inline to shell commands — backticks, `---`, and
+>   `*` get misinterpreted by shell parsers and security hooks. Write content to a temp file first,
+>   then reference by path. Use unique names: `/tmp/polyglot-<purpose>-<context>.txt`.
+>
+> **Read these files before writing anything:**
+>
+> - `thoughts/shared/research/2026-04-21-db-feature-architecture.md` (or `.compressed.md`)
+>   — the Architect's design doc; this is your primary constraint, not a script to follow
+> - `thoughts/shared/research/2026-04-21-db-schema-design.md` — the DBA's schema design
+> - `thoughts/shared/plans/2026-04-21-db-kotlin-feature.md` — implementation plan
+> - `kotlin/src/test/kotlin/bracketskt/BracketsTest.kt` — existing test style
+> - `kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/ApplicationGraphTest.kt`
+> - `kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/TestApplicationGraphModule.kt`
+> - `kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/BUILD.bazel`
+> - `kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/FakeTelemetryModule.kt`
+>
+> **Your role:** You are the TDD Designer for the database feature (PRs 3–5). You are not
+> primarily a test-writer — you are a tactical designer working test-first. The Architect has
+> established the strategic boundaries: which layers exist, where the seams are, what the
+> module decomposition should be. Within those boundaries, the detailed design is yours:
+> interface names, method signatures, error contracts, type shapes, test doubles. You
+> express your design decisions as tests. The Coder implements bodies; you define shapes.
+>
+> **Design responsibilities:**
+> - Where the Architect has left decisions open (and they will have deliberately left many),
+>   make those decisions yourself. The Architect's doc describes constraints and intent; you
+>   translate those into concrete Kotlin types and APIs.
+> - Define interfaces, data classes, and sealed types as needed. These definitions are your
+>   design output — not placeholders for someone else to rethink.
+> - Write tests that express the contract of each type and interface you define. Tests must
+>   compile. Tests must fail before the Coder writes any implementation.
+> - Do not write implementation logic. A `TODO()` body or an `abstract` method is design;
+>   a real implementation body is the Coder's domain.
+>
+> **Design and test principles:**
+> - Prefer narrow interfaces over wide ones. If `BalanceServiceEndpoint` only needs one method
+>   from the repository, define an interface with one method, not the whole repository.
+> - Prefer value types (data classes, sealed classes) at boundaries over primitive maps or
+>   strings where the type carries meaning.
+> - Use fakes over mocks. If a test needs a fake repository, write one — a few lines of
+>   in-memory state. Mocks couple tests to implementation details.
+> - Follow existing test patterns: JUnit 4 (`@Test`), Truth assertions.
+> - If a design decision feels like it might conflict with the Architect's intent — not just
+>   fill a gap, but potentially push against a stated constraint — check with the Architect
+>   before committing to it. Don't second-guess on small tactical choices; escalate genuine
+>   strategic tensions.
+>
+> **Cover at minimum:**
+>
+> 1. The repository contract (whatever interface/class shape you decide on):
+>    - Enabled pairs loaded correctly from an in-memory SQLite DB (with migration applied)
+>    - Disabled pairs ignored
+>    - Empty DB → empty result, no crash
+>    - close→open mapping direction correct
+>
+> 2. The service layer contract:
+>    - Known pair set → correct balance result (supply pairs directly, no DB involved)
+>    - Empty pair set → error response, not a crash
+>    - Unbalanced input → correct error shape and message
+>    - Characters not in the pair set treated as plain text
+>
+> 3. Dagger wiring:
+>    - Test graph builds with in-memory SQLite `DatabaseConfig`
+>    - Repository (or its interface) is injectable from test graph
+>    - Disabling a pair in the test DB causes that pair's characters to be accepted as plain text end-to-end
+>
+> **Placement:** Write types and tests in appropriate packages under `kotlin/src/main/kotlin/...`
+> (for type/interface definitions) and `kotlin/src/test/kotlin/...` (for tests and fakes). Add
+> Bazel `kt_jvm_test` targets in the relevant `BUILD.bazel` files following existing patterns.
+>
+> **When you are done:** Tell the Coder precisely: which files you have written, which
+> interfaces and types you have defined, which method bodies are `TODO()` for them to fill,
+> and any decisions you made that deviate from or extend the Architect's doc (so the Coder
+> understands the full contract). The Coder must not change any type or interface definition
+> you have produced without discussing it with you first. If you and the Coder cannot agree,
+> escalate to the Architect.
+
+---
+
+### Coder Agent Prompt
+
+> **Constraints (apply before doing any other work):**
+> - **VCS:** This repo uses `jj` (jujutsu). Never run `git` commands.
+> - **Build:** Use `bazel` (not `bazelisk`) for all build and test commands.
+> - **Style:** Run `ktfmt` on every `.kt` file you write or modify before considering your work done.
+> - **Shell safety:** Never pass non-trivial text inline to shell commands — backticks, `---`, and
+>   `*` get misinterpreted by shell parsers and security hooks. Write content to a temp file first,
+>   then reference by path. Use unique names: `/tmp/polyglot-<purpose>-<context>.txt`.
+>
+> **Read these files before writing any implementation:**
+>
+> - `thoughts/shared/research/2026-04-21-db-feature-architecture.md` (or `.compressed.md`)
+>   — the Architect's design doc; this is your primary reference
+> - `thoughts/shared/plans/2026-04-21-db-kotlin-feature.md` — implementation plan
+> - All type, interface, and test files written by the TDD Designer (they will tell you which files these are)
+> - `kotlin/src/main/kotlin/bracketskt/brackets.kt`
+> - `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BalanceServiceEndpoint.kt`
+> - `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/ApplicationGraph.kt`
+> - `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config/Config.kt`
+> - `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BUILD.bazel`
+> - `kotlin/BUILD.bazel`
+> - `MODULE.bazel`
+>
+> **Your role:** You are the Coder for the database feature (PRs 3–5). By the time you start,
+> the TDD Designer will have laid out the skeleton of the service changes: interfaces defined,
+> classes declared, module structure visible, method bodies stubbed with `TODO()`. The public
+> contract is decided. Everything below the public surface is yours: private types, private
+> functions, local names, internal helpers, utility extraction, how to structure internal state,
+> which third-party library calls to make. You have full creative latitude in that space.
+> If you discover that your implementation needs something that doesn't exist yet — a private
+> helper type, an internal utility, an extracted function — create it. You don't need to ask.
+>
+> **Rules:**
+> - Do not change public type definitions, interface signatures, class names, or public method
+>   signatures produced by the TDD Designer without their agreement. You may propose changes —
+>   implementation insight often reveals things the designer couldn't anticipate — but frame
+>   them as collaborative requests, not unilateral edits. If you and the TDD Designer agree,
+>   make the change. If you can't reach agreement, escalate to the Architect.
+> - If a test is impossible to satisfy without changing the public API contract, that is a
+>   reason to propose a change — bring it to the TDD Designer with a clear explanation.
+>   Do not silently modify the test or the interface.
+> - Run `ktfmt` on every `.kt` file you write or modify before considering any PR ready.
+>   (`ktfmt <file>` or `ktfmt $(find kotlin -name "*.kt")`).
+> - Follow existing Bazel patterns: `kt_jvm_library` for libraries, `java_binary` +
+>   `runtime_deps` for binaries, `associates = [...]` for internal member access in tests.
+>   Add new maven deps to `MODULE.bazel` `maven.install` artifacts.
+> - Keep H2 out of service runtime deps — it is build-time only (used by JOOQ DDLDatabase).
+> - Flyway must use `filesystem:` location (not classpath scanning) for Bazel runfiles
+>   compatibility. See the plan for the `RUNFILES_DIR` resolution pattern.
+> - The JOOQ `genrule` `outs` list must be exhaustive. Run codegen locally once, observe
+>   all generated files, then list them all. The build will fail if any are missing.
+>
+> **For each PR (3, 4, 5 in order):**
+> 1. Read the Architect's design and the TDD Designer's files for that PR's scope
+> 2. Implement until `bazel test //kotlin/...` passes for that PR's scope
+> 3. Run ktfmt on all changed files
+> 4. Report what you implemented and any deviations from the design (even minor ones)
+>
+> **Escalation:** If you and the TDD Designer reach an impasse on a public contract question,
+> bring the specific conflict to the Architect with a clear question. Do not resolve it
+> unilaterally. The Coordinator can break deadlocks if the Architect cannot resolve them.
+
+---
+
+## Steps
+
+### PR 1 — KT-007 (partial): Algorithm parameterization
+
+**Branch:** `kt-007-algorithm-param`  
+**Prereqs:** none — fully independent of all DB work  
+**Agents:** direct implementation (no three-agent workflow needed)
+
+Add an optional `pairs` parameter to `balancedBrackets` with the existing hardcoded map
+as the default. Existing call sites and all existing tests continue to pass without
+modification.
+
+```kotlin
+// brackets.kt — existing module-level vals stay unchanged
+val closedParentheses = mapOf(')' to '(', '}' to '{', ']' to '[')
+val openParentheses = closedParentheses.values.toSet()
+
+// New primary form — pairs maps close→open (same direction as existing map)
+fun balancedBrackets(text: String, pairs: Map<Char, Char> = closedParentheses) {
+    val opens = pairs.values.toSet()
+    // replace references to `closedParentheses` and `openParentheses` with `pairs` and `opens`
+    ...
+}
+```
+
+No new Bazel targets, no new deps, no config changes. Purely an algorithm API improvement.
+
+**Acceptance:**
+- `balancedBrackets` accepts an optional pair map
+- All existing `BracketsTest` cases pass without modification
+- `bazel test //kotlin/...` passes
+
+---
+
+### PR 2 — DB-001: Migration tooling and initial schema
+
+**Branch:** `db-001-schema-migrations`  
+**Prereqs:** none — fully independent  
+**Agents:** direct implementation (no three-agent workflow needed)
+
+1. Create `db/migrations/` at repo root.
+
+2. Validate filename convention (required before writing migrations):
+   - Configure Flyway with `sqlMigrationPrefix=""` and `sqlMigrationSeparator="_"`.
+   - Write a small standalone test (scratch script is fine) to confirm Flyway accepts
+     `20260421000000_create_bracket_pair.sql` as version `20260421000000`.
+   - If Flyway rejects the empty-prefix config, fall back to separate subdirs
+     (`flyway/` with `V1__create_bracket_pair.sql`, `dbmate/` with timestamp name,
+     same SQL in both); document the fallback in `db/README.md`.
+
+3. Write `db/migrations/20260421000000_create_bracket_pair.sql` (or `V1__...` if fallback):
+   ```sql
+   -- migrate:up
+   CREATE TABLE bracket_pair (
+       id         INTEGER  PRIMARY KEY,
+       open_char  CHAR(1)  NOT NULL,
+       close_char CHAR(1)  NOT NULL,
+       enabled    BOOLEAN  NOT NULL DEFAULT TRUE
+   );
+
+   INSERT INTO bracket_pair (id, open_char, close_char) VALUES (1, '(', ')');
+   INSERT INTO bracket_pair (id, open_char, close_char) VALUES (2, '[', ']');
+   INSERT INTO bracket_pair (id, open_char, close_char) VALUES (3, '{', '}');
+   ```
+
+4. Write `db/README.md` documenting:
+   - Dual-tool strategy (Flyway for JVM, dbmate for non-JVM)
+   - File format convention (`-- migrate:up`, no `-- migrate:down`)
+   - Filename convention (resolved from validation above)
+   - SQLite/PostgreSQL/H2 portability constraints
+
+5. Add Bazel `filegroup` to `db/BUILD.bazel`:
+   ```python
+   filegroup(
+       name = "migrations",
+       srcs = glob(["migrations/*.sql"]),
+       visibility = ["//visibility:public"],
+   )
+   ```
+
+6. Validate manually: run dbmate against the migration file and verify the table is created.
+
+**Acceptance:** `db/migrations/` exists, migration file validated against dbmate,
+`//db:migrations` filegroup defined, `db/README.md` written.
+
+---
+
+### Pre-PR 3 — Design phase (DBA + Architect)
+
+**Agents:** DBA agent, then Architect agent (see prompts above)  
+**Prereqs:** DB-001 merged (both agents need the actual schema)  
+**Output:** `thoughts/shared/research/2026-04-21-db-schema-design.md` + `.compressed.md` (DBA)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`thoughts/shared/research/2026-04-21-db-feature-architecture.md` + `.compressed.md` (Architect)
+
+For this project, run the DBA agent first (the schema is the primary new driver), then the
+Architect agent (reads the DBA's output). In the general pattern these two roles work
+collaboratively and iteratively rather than sequentially — see the workflow doc for context.
+
+Do not proceed to PRs 3–5 until both design docs exist and have been reviewed by the
+session coordinator (the human or coordinating agent).
+
+---
+
+### PR 3 — KT-005: JOOQ codegen (Bazel genrule)
+
+**Branch:** `kt-005-jooq-codegen`  
+**Prereq:** DB-001 merged  
+**Agents:** Tester then Coder (see prompts above); Architect available for consultation
+
+**New maven artifacts in `MODULE.bazel`:**
+- `org.jooq:jooq:3.19.x` (latest stable)
+- `org.jooq:jooq-kotlin:3.19.x`
+- `org.jooq:jooq-meta-extensions:3.19.x` (codegen only — DDLDatabase)
+- `org.jooq:jooq-codegen:3.19.x` (codegen only — GenerationTool)
+- `com.h2database:h2:2.x.x` (build-time only — DDLDatabase uses H2 internally to parse DDL)
+
+**Codegen runner:**
+
+Write a small Java/Kotlin main class (e.g. `JooqCodegenRunner`) that takes the DDL file
+path and output directory as CLI arguments, then calls `GenerationTool.generate(...)`
+programmatically with:
+- `Database`: `org.jooq.meta.extensions.ddl.DDLDatabase`
+- Input schema: the DDL path arg
+- Target package: `com.geekinasuit.polyglot.brackets.db.jooq`
+- Target directory: the output dir arg
+
+Wire into Bazel:
+```python
+# Runner binary (deps include jooq-codegen, jooq-meta-extensions, h2 — build time only)
+java_binary(
+    name = "jooq_codegen_runner",
+    main_class = "...",
+    runtime_deps = [":jooq_codegen_runner_lib"],
+)
+
+# genrule: migration SQL → generated Java sources
+genrule(
+    name = "jooq_generated_srcs",
+    srcs = ["//db:migrations"],
+    outs = [
+        "com/geekinasuit/polyglot/brackets/db/jooq/Tables.java",
+        "com/geekinasuit/polyglot/brackets/db/jooq/tables/BracketPair.java",
+        "com/geekinasuit/polyglot/brackets/db/jooq/tables/records/BracketPairRecord.java",
+        # ... run codegen locally once to discover the full outs list
+    ],
+    cmd = "$(location :jooq_codegen_runner) $(locations //db:migrations) $(@D)",
+    tools = [":jooq_codegen_runner"],
+)
+
+# Library wrapping generated sources; service code depends on this
+kt_jvm_library(
+    name = "jooq_db_lib",
+    srcs = [":jooq_generated_srcs"],
+    deps = ["@maven//:org_jooq_jooq"],
+    visibility = ["//visibility:public"],
+)
+```
+
+**Notes:**
+- JOOQ codegen produces Java sources (`.java`), not Kotlin — this is expected and standard
+- `jooq-kotlin` is a runtime extension (coroutine-friendly `fetchOne`, `map`, etc.); it adds
+  no generated `.kt` files
+- H2 is a build-time-only dep of the runner; it must not appear in service `runtime_deps`
+- The `outs` list must be exhaustive — run codegen locally once to discover all output files
+  before finalizing the genrule
+- Add all generated paths under `kotlin/` to `.gitignore` (consistent with proto codegen policy)
+
+**Acceptance:** `bazel build //kotlin/...` passes; `Tables`, `BracketPair`,
+`BracketPairRecord` classes available; generated files not committed to git.
+
+---
+
+### PR 4 — KT-006: Database adapter, Flyway, Dagger wiring
+
+**Branch:** `kt-006-database-adapter`  
+**Prereq:** DB-001 merged (KT-005 not required — can be prepared in parallel with PR 3)  
+**Agents:** Tester then Coder (see prompts above); Architect available for consultation
+
+**New maven artifacts in `MODULE.bazel`:**
+- `com.zaxxer:HikariCP:5.x.x`
+- `org.xerial:sqlite-jdbc:3.x.x`
+- `org.postgresql:postgresql:42.x.x`
+- `org.flywaydb:flyway-core:10.x.x`
+- `org.flywaydb:flyway-database-sqlite:10.x.x` (SQLite dialect support for Flyway 10+)
+
+**`Config.kt` changes:**
+
+Add `DatabaseConfig` and wire into `ServiceAppConfig`:
+```kotlin
+data class DatabaseConfig(
+    val url: String = "jdbc:sqlite::memory:",
+    val driver: String = defaultDriver(url),
+    val maxPoolSize: Int = 5,
+)
+
+fun defaultDriver(url: String): String = when {
+    url.startsWith("jdbc:sqlite") -> "org.sqlite.JDBC"
+    url.startsWith("jdbc:postgresql") -> "org.postgresql.Driver"
+    else -> error("Unsupported JDBC URL: $url")
+}
+
+data class ServiceAppConfig(
+    val service: ServiceConfig = ServiceConfig(),
+    val telemetry: TelemetryConfig = TelemetryConfig(),
+    val database: DatabaseConfig = DatabaseConfig(),
+)
+```
+
+**`service/application.yml` update:**
+```yaml
+service:
+  host: localhost
+  port: 8888
+database:
+  url: "jdbc:sqlite::memory:"
+  # driver and max-pool-size use defaults
+```
+
+**`DatabaseModule` Dagger module** (shape may be refined by Architect design doc):
+```kotlin
+@Module
+object DatabaseModule {
+    @Provides @ApplicationScope
+    fun dataSource(config: DatabaseConfig): DataSource {
+        // 1. Resolve migrations path from runfiles (see note below)
+        // 2. Build HikariCP pool from config
+        // 3. Run Flyway with filesystem: location pointing to resolved path
+        // 4. Return pool
+    }
+
+    @Provides @ApplicationScope
+    fun dslContext(dataSource: DataSource, config: DatabaseConfig): DSLContext {
+        val dialect = if (config.url.contains("sqlite")) SQLDialect.SQLITE
+                      else SQLDialect.POSTGRES
+        return DSL.using(dataSource, dialect)
+    }
+}
+```
+
+**Flyway runfiles path — key gotcha:**
+
+Flyway must use `filesystem:` location, not classpath scanning. Classpath scanning does not
+find files in Bazel runfiles trees. Resolve the path at runtime:
+```kotlin
+val migrationsPath = Paths.get(
+    System.getenv("RUNFILES_DIR") ?: ".",
+    "_main/db/migrations"
+).toAbsolutePath().toString()
+
+Flyway.configure()
+    .locations("filesystem:$migrationsPath")
+    .dataSource(dataSource)
+    .load()
+    .migrate()
+```
+
+**Wire into `ApplicationGraph`:**
+- Add `DatabaseModule` to `@Component(modules = [...])` in `ApplicationGraph`
+- `DatabaseConfig` is available via `ServiceAppConfig` — extract via a `@Provides` unwrapping
+  method (exact approach deferred to Architect design)
+
+**Bazel wiring:**
+- Add `//db:migrations` to `data` of `brackets_service` `java_binary` in `kotlin/BUILD.bazel`
+- Add new maven runtime deps to `service_lib` in `service/BUILD.bazel`
+
+**Tests:**
+- Include `DatabaseModule` in `TestApplicationGraph` with in-memory SQLite config
+- Existing `graphBuilds` and `serverProvides` tests must continue to pass
+- Verify Flyway migration runs without error on the test graph
+
+**Acceptance:** `bazel test //kotlin/...` passes; service starts; Flyway migration applies
+on startup; in-memory SQLite works in tests.
+
+---
+
+### PR 5 — KT-007 (remainder): Repository, service wiring, tests
+
+**Branch:** `kt-007-bracket-config`  
+**Prereqs:** PR 1 (algorithm param), KT-005, KT-006 all merged  
+**Agents:** Tester then Coder (see prompts above); Architect available for consultation
+
+**`BracketPairRepository`** in new package `com.geekinasuit.polyglot.brackets.db`
+(exact interface shape from Architect design doc):
+```kotlin
+@ApplicationScope
+class BracketPairRepository @Inject constructor(private val dsl: DSLContext) {
+    fun loadEnabledPairs(): Map<Char, Char> =
+        dsl.selectFrom(Tables.BRACKET_PAIR)
+           .where(Tables.BRACKET_PAIR.ENABLED.isTrue)
+           .fetch()
+           .associate { row ->
+               row.get(Tables.BRACKET_PAIR.CLOSE_CHAR).single() to
+               row.get(Tables.BRACKET_PAIR.OPEN_CHAR).single()
+           }
+}
+```
+
+**Dagger wiring:**
+
+Add a module providing the pair map at `@ApplicationScope`:
+```kotlin
+@Module
+object BracketConfigModule {
+    @Provides @ApplicationScope
+    fun bracketPairs(repo: BracketPairRepository): Map<Char, Char> =
+        repo.loadEnabledPairs()
+}
+```
+
+Install `BracketConfigModule` in `ApplicationGraph`. If no pairs are enabled, the service
+returns an error response rather than crashing — check for empty map in
+`BalanceServiceEndpoint`.
+
+**`BalanceServiceEndpoint` update:**
+
+Inject `Map<Char, Char>` and pass it through:
+```kotlin
+class BalanceServiceEndpoint @Inject constructor(
+    otel: OpenTelemetry,
+    private val bracketPairs: Map<Char, Char>,
+) : BalanceBracketsGrpc.AsyncService { ... }
+```
+
+**Tests:**
+- `BracketPairRepositoryTest`: in-memory SQLite `DSLContext`, apply migration via Flyway,
+  insert test rows, assert `loadEnabledPairs()` returns correct close→open map
+- `BalanceServiceEndpointTest`: supply a known pair map as constructor arg (no DB needed)
+- Disable-pair test: insert rows with `enabled=false` for `()`, assert those characters
+  are treated as plain text by the algorithm
+- `ApplicationGraphTest` updates: supply `DatabaseConfig` with in-memory SQLite so the
+  full graph (now including `BracketConfigModule`) builds cleanly
+
+**Bazel wiring:**
+- New `kt_jvm_library` target for the `db` package (depends on `jooq_db_lib` from KT-005)
+- Add it to `service_lib` deps in `service/BUILD.bazel`
+
+**Acceptance:** `bazel test //kotlin/...` passes; bracket pairs are loaded from DB;
+disabling a pair in the test DB causes the algorithm to treat those characters as plain text.
+
+---
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Flyway rejects empty-prefix + single-`_` separator | Validate first (step 2 of PR 2); fallback to separate filename sets fully documented |
+| JOOQ genrule `outs` must be listed exhaustively | Run codegen locally once before finalizing; discover all output files |
+| Flyway classpath scan misses Bazel runfiles | Use `filesystem:` location with `RUNFILES_DIR` resolution (see PR 4 detail) |
+| H2 DDL compatibility | Stick to safe subset; test locally |
+| Dagger raw `Map<Char, Char>` binding collision | Use `@Named` qualifier or a wrapper type if Dagger complains |
+| Architect/Tester/Coder deadlock | Coordinator breaks deadlock; Architect is authority on API shape |
+
+---
+
+## Acceptance Criteria (Summary)
+
+- [ ] PR 1: `balancedBrackets` accepts optional pair map; all existing tests pass unchanged
+- [ ] Architect doc: `thoughts/shared/research/2026-04-21-db-feature-architecture.md` exists and reviewed
+- [ ] PR 2: `db/migrations/` + validated migration file + `//db:migrations` filegroup + `db/README.md`
+- [ ] PR 3: JOOQ genrule produces `Tables`, `BracketPair`, `BracketPairRecord`; `.gitignore`d; `bazel build` passes
+- [ ] PR 4: `DatabaseConfig` in `Config.kt`; `service/application.yml` default SQLite; `DatabaseModule` provides `DataSource` + `DSLContext`; Flyway runs on startup; `bazel test` passes
+- [ ] PR 5: `BracketPairRepository` loads enabled pairs; `BalanceServiceEndpoint` uses injected map; all tests pass; `bazel test //kotlin/...` passes

--- a/thoughts/shared/research/2026-04-21-multi-agent-tdd-workflow.compressed.md
+++ b/thoughts/shared/research/2026-04-21-multi-agent-tdd-workflow.compressed.md
@@ -1,0 +1,171 @@
+<!--COMPRESSED v1; source:2026-04-21-multi-agent-tdd-workflow.md-->
+§META
+date:2026-04-21 researcher:claude+cgruber commit:7894102bc653 branch:main
+repo:geekinasuit/polyglot topic:multi-agent TDD workflow pattern
+tags:agents,tdd,architecture,workflow,pattern
+status:draft — in use on DB feature; refine as experience accumulates
+
+§SUMMARY
+Six-role pattern for non-trivial multi-layer features (4 active, 2 TBD). Separates data design, strategic API
+design, tactical type+test design, and implementation into specialist roles with clear handoffs.
+First applied: DB feature (DB-001,KT-005,KT-006,KT-007).
+
+§WHEN_TO_USE
+apply when: feature spans multiple layers | meaningful design decisions at strategic+tactical level |
+  benefits from TDD | complex enough single agent loses coherence
+skip when: single-layer change, bug fix, config addition, one-file feature
+
+§ROLES
+
+Product Owner [TBD — not yet defined]
+  domain: customer+business requirements; what system should do+why; priority tradeoffs; acceptance criteria
+  sits upstream of Architect (defines problem space Architect designs solution for)
+  not yet relevant: polyglot is an exemplar not a product; will matter when used as app template
+  without PO: Architect absorbs this by default
+  needs definition: how PO→Architect→TDD Designer flow works; how acceptance criteria become test surfaces
+
+UI/UX Designer [TBD — CLI partially relevant now]
+  domain: user-facing interaction design per modality
+  modality specialisations: CLI | web | Android | iOS | desktop
+  CLI relevant now: Kotlin service has CLI client; flag names, output format, error messages are UX decisions
+    currently made implicitly by implementers — a CLI UX role would make them explicit+consistent
+  other modalities: not yet relevant; will matter when polyglot used as app template
+  sits between PO(what users need) and TDD Designer(how needs become types+behaviours)
+  needs definition: how modality specialisation is specified in prompt; how UX decisions reach TDD Designer
+
+DBA
+  domain: schema, migrations, seeding, DB portability, test data strategy
+  typical flow: Architect drives the need; DBA serves+negotiates schema to satisfy it — round-trip not handoff
+  authority on data/schema questions; but serving architectural intent, not driving it
+  not responsible for: Kotlin code, Dagger wiring, API design, test framework
+
+Architect
+  domain: CRC-card level or coarser — subsystems, responsibilities, high-level collaborations, flow
+  typical flow: drives the need; DBA negotiates schema to serve it; both iterate to consensus
+  co-produces Phase 1 with DBA — does not simply consume DBA output
+  CAN recommend class structures ("a repository responsible for X, collaborating with Y")
+  stops short of: exact method sigs, error contracts, internal state — TDD Designer's domain
+  establishes constraints+intent, not complete spec
+  not responsible for: schema details, migration tooling, exact method sigs, error contracts, test bodies
+
+TDD Designer
+  domain: tactical API completion + test-first expression
+  NOT primarily a test-writer — tactical designer working test-first
+  fills Architect's open space: interface names, method sigs, error contracts, type shapes, test doubles
+  produced types+interfaces = public contract Coder must implement (not placeholders)
+  design principles: narrow interfaces; value types over primitives at boundaries; fakes not mocks
+  not responsible for: implementation bodies, private helper extraction, internal state
+
+Coder
+  domain: private implementation — everything below the public surface
+  full creative latitude: private types, fns, local names, helpers, utility extraction, internal state, lib calls
+  may PROPOSE public contract changes (impl insight often reveals gaps) → collaborative request to TDD Designer
+  not responsible for: public type defs, interface sigs, module boundaries (unless negotiated)
+
+§WORKFLOW
+Phase 1 (once, before impl):
+  Architect ↔ DBA [collaborative, iterative — not sequential]
+    Architect: establishes need, quality constraints, structural intent
+    DBA: proposes schema to serve that intent; negotiates data model constraints back
+    iterate to consensus → schema design doc (DBA) + API+Dagger design doc (Architect)
+  NOTE this project ran DBA→Architect because retrofitting DB onto existing app (schema was primary driver)
+    that's the exception; in greenfield features Architect drives, DBA serves
+
+Phase 2 (per PR, in order):
+  TDD Designer [reads both docs] → type defs + interface decls + class skeletons + tests(red)
+    handoff: files written; contracts defined; TODO() bodies for Coder
+  Coder [reads both docs + TDD Designer files] → implementation bodies + private helpers
+    may propose public changes back to TDD Designer
+
+§ESCALATION
+| Question | First | If unresolved |
+|---|---|---|
+| schema/migration/data | DBA | Architect |
+| strategic API/module boundaries | Architect | Coordinator |
+| tactical type/interface | TDD Designer | Architect |
+| public contract change proposal | TDD Designer | Architect |
+| deadlock any two agents | Architect | Coordinator |
+Coordinator = outer session; breaks deadlocks only
+
+§CONSTRAINTS
+subagents start cold — embed constraints directly in each prompt; never assume inheritance
+
+DBA + Architect:
+  compressed-format: read /opt/geekinasuit/agents/internal/workflows/compressed-format.compressed.md
+    applies to .md docs only — .sql/.kt/other non-prose = no compressed form
+    produce both .md + .compressed.md for output docs
+  shell-safety: no inline non-trivial text in shell cmds; write to /tmp/<repo>-<purpose>-<ctx>.txt
+
+TDD Designer + Coder:
+  VCS: jj only; never git
+  build: bazel not bazelisk (or project equivalent)
+  style: run formatter (ktfmt/gofmt/etc.) on all modified source files before done
+  shell-safety: same as above
+[adjust VCS/build/style per target repo toolchain; shell-safety is universal]
+
+§PROMPT_TEMPLATES
+
+DBA:
+  constraints: compressed-format + shell-safety
+  read: <PLAN>; <TICKETS:data layer>
+  role: DBA+data architect for <FEATURE>; Architect reads your output — constrain them accurately
+  design: schema DDL+portability; migration tooling+validation; seed strategy; future evolution;
+    test data isolation; build system integration
+  output: <SCHEMA_DOC>.md + .compressed.md; mark fixed|provisional
+
+Architect:
+  constraints: compressed-format + shell-safety
+  read: <SCHEMA_DOC>[first]; <PLAN>; <TICKETS:app layer>; relevant source files
+  role: architect for <FEATURE>; design strategic constraints+intent; leave tactical space for TDD Designer
+  design: layer boundaries+testability rationale; module decomposition+independent overridability;
+    DI wiring; lifecycle sequencing; future-proofing; test surfaces by layer; explicit open decisions
+  output: <ARCH_DOC>.md + .compressed.md; mark fixed|provisional
+
+TDD Designer:
+  constraints: VCS + build + style + shell-safety
+  read: <ARCH_DOC>[primary constraint, not complete spec]; <SCHEMA_DOC>; <PLAN>; existing test files
+  role: tactical designer test-first; fill Architect's open space with concrete types+tests
+    your type+interface defs = design output, not placeholders
+  principles: narrow interfaces; value types at boundaries; fakes not mocks; open decisions→make them+document
+  cover: repository contract(happy/edge/error); service layer(direct input/empty/error); DI wiring+e2e
+  placement: type+interface defs in main src; tests+fakes in test src; add build targets
+  handoff: tell Coder — files; interfaces; TODO() bodies; deviations from Arch doc
+  Coder must not change your sigs without TDD Designer agreement + possible Architect escalation
+
+Coder:
+  constraints: VCS + build + style + shell-safety
+  read: <ARCH_DOC>; <SCHEMA_DOC>; <PLAN>; all TDD Designer files (they list these); relevant src
+  role: fill implementation bodies; public contract is fixed; private domain is yours
+  private domain: private types, fns, local names, helpers, utility extraction, internal state, lib calls — create freely
+  may propose public changes: collaborative request to TDD Designer; agree→proceed; disagree→Architect
+  impossible test: explain to TDD Designer; escalate if unresolved; never silent change
+  per PR: read docs+tests → implement → build+test passes → format → report deviations
+
+§NOTES
+2026-04-21: first defined; not yet validated in practice — treat as provisional until one full feature cycle completes
+
+§OPEN_QUESTIONS
+sync vs async TDD Designer↔Coder:
+  preferred=synchronous(more collaborative, closer to pair programming)
+  open=coordination overhead — how hard in practice? explore before committing to default
+  current plan=async(simpler starting point)
+
+minimum feature size for DBA+Architect separately:
+  "two perspectives" valuable even on small things (cf. pair programming on one-liners)
+  probably a floor somewhere; a single-table+single-endpoint feature may only need Architect
+  track against real examples; let evidence drive, not theory
+
+specialist overhead vs. value as roster grows:
+  defined roles: 6 (4 active: DBA,Architect,TDD Designer,Coder; 2 TBD: PO,UI/UX)
+  at some point coordination cost (spin up, brief, route) > value of separation
+  question: "does this feature have enough complexity in this role's domain to justify it?"
+  not yet critical; revisit when real app features with genuine UX+product requirements are in scope
+
+Architect doc currency + granularity:
+  hold at CRC-card level or coarser: subsystems, responsibilities, high-level collaborations, flow
+  Architect CAN name classes but at responsibility level ("a repository for X collaborating with Y")
+  NOT exact method sigs, error contracts, internal state — that's TDD Designer resolution
+  granularity boundary IS the role boundary: Architect=subsystem/responsibility/flow; TDD Designer=interface/sig/contract
+  TDD Designer details do NOT propagate back up to Arch doc
+  update Arch doc only when responsibilities, subsystem boundaries, or high-level collaborations change
+  all arch docs go out of date — acceptable; periodic refresh from code analysis > perfect sync

--- a/thoughts/shared/research/2026-04-21-multi-agent-tdd-workflow.md
+++ b/thoughts/shared/research/2026-04-21-multi-agent-tdd-workflow.md
@@ -1,0 +1,393 @@
+---
+date: 2026-04-21
+researcher: claude + cgruber
+git_commit: 7894102bc653
+branch: main
+repository: geekinasuit/polyglot
+topic: Multi-agent TDD workflow pattern
+tags: agents, tdd, architecture, workflow, pattern
+status: draft — in use on DB feature; refine as experience accumulates
+last_updated: 2026-04-21
+last_updated_by: claude
+---
+
+# Multi-Agent TDD Workflow Pattern
+
+A pattern for implementing non-trivial features using specialist agents with distinct
+roles and clear handoff points. Six roles are defined: four currently active (DBA, Architect,
+TDD Designer, Coder) and two stubbed as TBD (Product Owner, UI/UX Designer). Designed for features that span multiple layers (data,
+infrastructure, service logic) and benefit from separation of concerns at the agent level.
+
+First applied: DB feature (DB-001, KT-005, KT-006, KT-007) in this repo.
+
+---
+
+## When to Use
+
+Apply this pattern when a feature:
+- Spans multiple architectural layers (e.g. data schema → infrastructure → service API)
+- Has meaningful design decisions at both the strategic and tactical level
+- Benefits from test-driven development with a clear public contract
+- Is complex enough that a single agent would lose coherence across the full scope
+
+For simple, single-layer changes (a bug fix, a config addition, a one-file feature),
+this pattern is overkill. Apply judgment.
+
+---
+
+## Roles
+
+### Product Owner *(TBD — not yet defined)*
+**Domain:** Customer and business requirements — what the system should do and why, priority
+tradeoffs, acceptance criteria from the user's perspective.
+
+Not yet relevant to this project (polyglot is an exemplar, not a product), but will matter
+when polyglot is used as a template for real applications. The Product Owner would sit
+upstream of the Architect, defining the problem space the Architect designs a solution for.
+Without a Product Owner, the Architect absorbs this responsibility by default.
+
+*Needs definition: how the PO interacts with the Architect and TDD Designer; how acceptance
+criteria flow into the test surfaces the TDD Designer defines.*
+
+---
+
+### UI/UX Designer *(TBD — partially relevant now)*
+**Domain:** User-facing interaction design, appropriate to the modality. Possible
+specialisations: CLI, web, Android, iOS, desktop.
+
+**CLI is probably relevant now** — the Kotlin service has a CLI client, and decisions about
+flag names, output format, and error messages are UX decisions that currently get made
+implicitly by whoever is implementing. A CLI UX Designer role could make those decisions
+explicit and consistent.
+
+Other modalities (web, mobile, desktop) are not yet relevant to this project but will be
+when polyglot is used as an app template. The UI/UX Designer would sit between the Product
+Owner (what users need) and the TDD Designer (how those needs become concrete types and
+behaviours), with the Architect ensuring the technical structure can support the UX intent.
+
+*Needs definition: how the modality specialisation is specified in the prompt; how UX
+decisions propagate into the TDD Designer's type and API choices.*
+
+---
+
+### DBA
+**Domain:** Data layer — schema, migrations, seeding, DB portability, test data strategy.
+
+The DBA is the authority on anything that touches the database directly. In a typical
+feature, the Architect establishes what the system needs to do, and the DBA negotiates
+the schema that best serves that purpose — it's a round-trip, not a one-way handoff.
+The DBA brings data modelling expertise; the Architect brings system design intent; they
+meet in the middle. All data/schema questions route to the DBA, but the DBA is serving the
+architectural need, not driving it.
+
+Not responsible for: Kotlin code, Dagger wiring, API design, test framework choices.
+
+### Architect
+**Domain:** Strategic API shape — layer boundaries, module decomposition, Dagger graph
+structure, long-term extensibility, interface topology.
+
+In a typical feature, the Architect drives the need: what does the system have to do, how
+should it be structured, what are the quality constraints. The DBA then negotiates the schema
+to serve that intent, and the two iterate toward a design that satisfies both. The Architect
+does not simply consume the DBA's output — they co-produce Phase 1 with the DBA.
+
+The Architect works at CRC-card level or coarser: subsystems, responsibilities, high-level
+collaborations and flow. They may recommend class structures ("there should be a repository
+responsible for loading pairs, collaborating with the DSL context") but stop short of exact
+method signatures, error contracts, or internal state. Those details are the TDD Designer's
+domain. The Architect establishes constraints and intent, not a complete spec.
+
+Not responsible for: schema details, migration tooling, exact method signatures, error
+contracts, concrete type names, test bodies.
+
+### TDD Designer
+**Domain:** Tactical API completion + test-first expression of that design.
+
+The TDD Designer is not primarily a test-writer — they are a tactical designer working
+test-first. The Architect establishes strategic boundaries; the TDD Designer fills the
+space within those boundaries: interface names, method signatures, error contracts, type
+shapes, test doubles. Their design decisions are expressed as tests. The code they produce
+(type definitions, interface declarations, class skeletons with `TODO()` bodies) constitutes
+the public contract that the Coder must implement.
+
+Design principles:
+- Prefer narrow interfaces over wide ones
+- Prefer value types (data classes, sealed classes) over primitives at boundaries where
+  the type carries meaning
+- Use fakes over mocks — a few lines of in-memory state couples less than a mock framework
+- Where the Architect left a decision open, make it yourself; document the rationale
+
+Not responsible for: implementation bodies, private helper extraction, internal state structure.
+
+### Coder
+**Domain:** Private implementation — everything below the public surface.
+
+The Coder has full creative latitude in the private space: private types, private functions,
+local names, internal helpers, utility extraction, internal state management, third-party
+library call choices. They do not need permission to create things in the private space.
+
+The Coder may also propose changes to the public contract when implementation insight reveals
+gaps or problems the TDD Designer couldn't anticipate from the outside. These are collaborative
+requests to the TDD Designer — not unilateral edits.
+
+Not responsible for: public type definitions, interface signatures, module boundaries (unless
+negotiated), test bodies.
+
+---
+
+## Workflow Sequence
+
+```
+Phase 1: Design (runs once, before any implementation)
+
+  Architect ←→ DBA  [collaborative, iterative]
+    Architect: establishes system need, quality constraints, structural intent
+    DBA: proposes schema to serve that intent; negotiates data model constraints back
+    iterate until both are satisfied
+    └─→ produces: schema design doc (DBA) + API/Dagger design doc (Architect)
+
+Phase 2: Implementation (per PR, in order)
+
+  TDD Designer  [reads both design docs]
+    └─→ produces: type definitions, interface declarations, class skeletons, tests (red)
+         └─→ handoff to Coder: files written, contracts defined, TODO() bodies to fill
+
+  Coder  [reads both design docs + TDD Designer's files]
+    └─→ produces: implementation bodies, private helpers
+         └─→ may propose public contract changes back to TDD Designer
+```
+
+Phase 1 runs once for the whole feature. Phase 2 repeats per PR if the feature spans
+multiple PRs (TDD Designer and Coder work through each PR in order before moving to the next).
+
+**Note on this project's unusual sequencing:** The DB feature in this repo ran DBA first,
+then Architect, because we were retrofitting a database requirement onto an existing
+application — the schema was the primary new driver, and the Architect was adapting to it.
+That's the exception, not the rule. In a greenfield feature, the Architect drives the need
+and the DBA serves it.
+
+---
+
+## Escalation Chain
+
+| Question type | First stop | If unresolved |
+|---|---|---|
+| Schema, migration, data | DBA | Architect |
+| Strategic API shape, module boundaries | Architect | Coordinator |
+| Tactical type/interface details | TDD Designer | Architect |
+| Public contract change proposal | TDD Designer | Architect |
+| Deadlock between any two agents | Architect | Coordinator |
+
+The **Coordinator** is the outer session (human or orchestrating agent) running the subagents.
+The Coordinator breaks deadlocks only — after the relevant specialist agents have been consulted.
+
+---
+
+## Constraints by Role
+
+These constraints must be embedded in each agent's prompt directly — subagents start cold
+and do not inherit the session's system prompt or bootstrap chain.
+
+### DBA and Architect
+```
+Compressed format: Read /opt/geekinasuit/agents/internal/workflows/compressed-format.compressed.md
+  before producing output docs. Applies to .md research docs only — .sql, .kt, and other
+  non-prose files have no compressed form. Produce both .md and .compressed.md for your output.
+Shell safety: Never pass non-trivial text inline to shell commands. Write to a temp file
+  first, reference by path. Use unique names: /tmp/<repo>-<purpose>-<context>.txt
+```
+
+### TDD Designer and Coder
+```
+VCS: This repo uses jj (jujutsu). Never run git commands.
+Build: Use bazel (not bazelisk) for all build and test commands.
+Style: Run ktfmt on every .kt file you write or modify before considering work done.
+Shell safety: (same as above)
+```
+
+Adjust the VCS/build/style constraints to match the target repo's toolchain. The shell
+safety rule applies universally.
+
+---
+
+## Agent Prompt Templates
+
+The prompts below are templates. Replace `<SCHEMA_DOC>`, `<ARCH_DOC>`, `<PLAN>`,
+`<TICKETS>`, and file paths with the actual values for the feature being implemented.
+
+### DBA Prompt Template
+
+```
+Constraints:
+- Compressed format: [see above]
+- Shell safety: [see above]
+
+Read first:
+  <PLAN>
+  <TICKETS relevant to data layer>
+
+Role: DBA and data architect for <FEATURE>. Design schema, migrations, seeding, test data
+strategy. The Architect will read your output — be precise about anything that constrains
+the application layer (column types, nullability, migration sequencing, test isolation).
+
+Design and document:
+1. Schema: finalize DDL; verify portability across target DB engines; rationale per choice
+2. Migration tooling: filename conventions, tool compatibility, validation
+3. Seed data strategy: where seed data lives; how tests reset/override it cleanly
+4. Future evolution: what changes are plausible; does initial schema foreclose any paths
+5. Test data strategy: how integration tests get a clean, reproducible DB state
+6. Build integration: how migration files are exposed to the build system
+
+Output: <SCHEMA_DOC>.md + <SCHEMA_DOC>.compressed.md
+Mark each decision: fixed | provisional
+```
+
+### Architect Prompt Template
+
+```
+Constraints:
+- Compressed format: [see above]
+- Shell safety: [see above]
+
+Read first:
+  <SCHEMA_DOC> [DBA output — read this first]
+  <PLAN>
+  <TICKETS relevant to application layer>
+  <relevant existing source files>
+
+Role: Architect for <FEATURE>. Design API surfaces, module decomposition, Dagger graph,
+test seams. Not implementation. The TDD Designer will fill the tactical details you leave
+open — establish constraints and intent, not a complete spec.
+
+Design and document:
+1. Layer boundaries: what interfaces exist at each layer boundary; testability rationale
+2. Module decomposition: which modules, what each provides; can pieces be overridden
+   independently in tests?
+3. Dependency injection wiring: how config and dependencies flow through the graph
+4. Lifecycle and startup sequencing: who is responsible for what, in what order
+5. Future-proofing: what likely changes should the design not foreclose
+6. Test surfaces: what is tested at unit vs. integration level; what doubles are needed
+7. Explicit open decisions: what you are deliberately leaving to the TDD Designer
+
+Output: <ARCH_DOC>.md + <ARCH_DOC>.compressed.md
+Mark: fixed (TDD Designer and Coder must not deviate) | provisional (TDD Designer may refine)
+```
+
+### TDD Designer Prompt Template
+
+```
+Constraints:
+- VCS, build, style, shell safety: [see above]
+
+Read first:
+  <ARCH_DOC> [primary constraint — strategic boundaries, not a complete spec]
+  <SCHEMA_DOC> [DBA output]
+  <PLAN>
+  <existing test files for style reference>
+
+Role: TDD Designer for <FEATURE>. Tactical designer working test-first. The Architect has
+set the strategic boundaries; you fill the space within them: interface names, method
+signatures, error contracts, type shapes, test doubles. Your type and interface definitions
+are design output — not placeholders for the Coder to rethink.
+
+Design and test principles:
+- Prefer narrow interfaces; prefer value types over primitives at boundaries
+- Write fakes, not mocks; JUnit 4 + Truth (or project-standard test framework)
+- Where Architect left a decision open, make it yourself; document rationale in comments
+- Genuine strategic tensions → check with Architect before committing
+- Tests must compile and fail before Coder starts
+
+Coverage (adapt to feature):
+- Each repository/data-access contract: happy path, edge cases, error conditions
+- Each service-layer contract: with direct inputs (no DB), empty/error states
+- Dagger/DI wiring: test graph builds; components are injectable; end-to-end scenario
+
+Placement: type/interface definitions in main source tree; tests and fakes in test tree
+Add build targets following existing patterns.
+
+Handoff: tell Coder — files written, interfaces defined, TODO() bodies for them to fill,
+any decisions that extend or deviate from Architect doc.
+Coder must not change your type/interface/sig definitions without agreement + escalation.
+```
+
+### Coder Prompt Template
+
+```
+Constraints:
+- VCS, build, style, shell safety: [see above]
+
+Read first:
+  <ARCH_DOC> [primary reference]
+  <SCHEMA_DOC> [DBA output]
+  <PLAN>
+  <all files produced by TDD Designer — they will list these>
+  <relevant existing source files>
+
+Role: Coder for <FEATURE>. The TDD Designer has laid out the skeleton: interfaces defined,
+classes declared, module structure visible, method bodies stubbed with TODO(). The public
+contract is decided. Your domain is everything below the public surface: private types,
+private functions, local names, internal helpers, utility extraction, internal state,
+third-party library call choices. You have full creative latitude here — create freely.
+
+You may also propose changes to the public contract when implementation reveals gaps the
+designer couldn't anticipate from the outside. Bring these as collaborative requests to
+the TDD Designer. If you agree, proceed. If not, escalate to the Architect.
+
+Rules:
+- No unilateral changes to public types, interfaces, signatures, or class names
+- Propose public changes to TDD Designer; escalate disagreements to Architect
+- Impossible test → explain the conflict to TDD Designer; escalate if unresolved
+- [repo-specific build rules, style tools, dependency management]
+
+Per PR: read design docs + TDD Designer files → implement → [build+test command] passes
+→ run formatter → report any deviations from the design docs.
+```
+
+---
+
+## Notes and Refinements
+
+*(Add observations here as the pattern is used in practice)*
+
+- **2026-04-21:** First defined during DB feature planning session. Pattern not yet validated
+  in practice — treat prompt templates as provisional until at least one full feature cycle
+  completes.
+
+---
+
+## Open Questions
+
+- **Sync vs. async between TDD Designer and Coder.** Synchronous back-and-forth is the
+  preferred model — more collaborative, closer to pair programming. The open question is
+  coordination overhead: how hard is it to run two agents in a genuine dialogue vs. clean
+  sequential handoffs? Need to explore in practice before committing to either as default.
+  Current plan uses async as the simpler starting point.
+
+- **Minimum feature size to justify DBA + Architect separately.** The "two perspectives"
+  argument holds even for small things — pair programming is valuable on a one-liner. But
+  there's probably a floor somewhere. A feature with one table and one endpoint might only
+  need the Architect. Track against real examples as the pattern is used; let evidence drive
+  the answer rather than theory.
+
+- **Specialist overhead vs. value as the roster grows.** The pattern currently defines six
+  roles (four active, two TBD). At some point the coordination cost of spinning up, briefing, and routing between
+  specialists exceeds the value of the separation. This tradeoff is manageable now but will
+  need revisiting when real app features (with genuine UX and product requirements) are in
+  scope. The question isn't just "is this role valuable in theory" but "does this feature
+  have enough complexity in this role's domain to justify it."
+
+- **Architecture doc currency and granularity.** Keep the Architect doc in sync as
+  implementation proceeds, but hold it at CRC-card level or coarser — subsystems, overall
+  responsibilities, high-level collaborations and flow. The Architect *can* recommend class
+  structures, but names them at the level of "there should be a repository responsible for
+  loading pairs, collaborating with the DSL context" rather than specifying exact method
+  signatures, error contracts, or internal state. That detailed level is the TDD Designer's
+  domain. The granularity boundary is the key distinction between the two roles: Architect
+  works at subsystem/responsibility/flow resolution; TDD Designer works at
+  interface/signature/contract resolution.
+
+  Implementation-level details that the TDD Designer fills in do not need to propagate back
+  up; only changes that affect stated responsibilities, subsystem boundaries, or high-level
+  collaborations warrant an Architect doc update. All architecture documents go out of date
+  eventually — that's acceptable. A periodic refresh from code analysis is healthier than
+  trying to keep perfect sync.


### PR DESCRIPTION
## Prerequisites
- [x] N/A

## Summary
- Add 5-PR implementation plan for DB feature (DB-001, KT-005, KT-006, KT-007): algorithm parameterization, schema/migrations, JOOQ codegen, DB adapter, repository+service wiring
- Add multi-agent TDD workflow pattern document (DBA, Architect, TDD Designer, Coder) as reusable research doc for future features
- Both docs produced in .md + .compressed.md form per convention

## Validation performed
- [x] N/A — Category A (prose/docs), no validation required

## Affected machines / services
- N/A — documentation only

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- see #DB-001, see #KT-005, see #KT-006, see #KT-007 (planning documents only; implementation not started)

## Rollback
- N/A — revert commit

