### PR TITLE
ci: retry Kotlin integration test steps on transient failure (mitigation for CI-003)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -102,6 +102,10 @@ steps:
 
   - label: ":kotlin: Kotlin integration test (Linux)"
     depends_on: test-linux
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 2
     plugins:
       - docker#v5.11.0:
           image: "local/ci-agent:latest"
@@ -121,6 +125,10 @@ steps:
 
   - label: ":apple: :kotlin: Kotlin integration test (macOS)"
     depends_on: test-macos
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 2
     agents:
       os: macos
     command: .buildkite/scripts/kotlin-integration-test.sh

--- a/thoughts/shared/tickets/CI-003-integration-test-grpc-readiness-probe.md
+++ b/thoughts/shared/tickets/CI-003-integration-test-grpc-readiness-probe.md
@@ -1,0 +1,30 @@
+---
+id: CI-003
+title: Replace TCP readiness check with gRPC-level probe in Kotlin integration test
+area: ci, testing, kotlin
+status: open
+created: 2026-04-21
+---
+
+## Summary
+
+The Kotlin integration test script checks for TCP connectivity before sending requests, but Armeria's gRPC stack may not be ready to process requests at the moment the TCP socket opens. This causes intermittent socket-disconnection failures on server startup.
+
+## Current State
+
+`.buildkite/scripts/kotlin-integration-test.sh` uses `/dev/tcp/localhost/${PORT}` to detect when the service is ready. TCP-open does not guarantee gRPC is ready — Armeria accepts connections before its request pipeline is fully initialized. The result is an occasional reset/disconnection on the very first client call.
+
+Mitigation in place: Buildkite step-level `retry.automatic` (added in CI-003's companion PR) reduces perceived flake rate, but does not fix the root cause.
+
+## Goals / Acceptance Criteria
+
+- [ ] Replace the TCP-only readiness loop with a probe that confirms gRPC is actually ready to handle requests — e.g. a short retry loop on the first real client call (with brief backoff), or a dedicated gRPC health-check probe if a health endpoint is added
+- [ ] Server startup race is eliminated: first test invocation does not fail due to a partially-initialized gRPC stack
+- [ ] No increase in average CI wall time (probe should be fast on the happy path)
+- [ ] Both Linux and macOS integration test steps pass reliably
+
+## References
+
+- Script: `.buildkite/scripts/kotlin-integration-test.sh:50-58` (TCP readiness loop)
+- Pipeline: `.buildkite/pipeline.yml` (Kotlin integration test steps)
+- Server entry point: `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/service.kt`

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -51,6 +51,7 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 | `KT-002-kotlin-dagger-grpc-di.md` | kotlin, grpc, di | Introduce Dagger 2 DI for the Kotlin service via dagger-grpc |
 | `KT-003-kotlin-dagger-client-di.md` | kotlin, grpc, di | Dagger DI for the gRPC client binary; prereq: server DI ticket |
 | `CI-002-cross-language-e2e-matrix.md` | testing, ci, grpc, multi-language | Matrix test for every (client lang) × (server lang) combination; prereq: all gRPC client+server tickets |
+| `CI-003-integration-test-grpc-readiness-probe.md` | ci, testing, kotlin | Replace TCP readiness check with gRPC-level probe; root cause of socket-disconnection flakes on startup |
 | `GO-001-go-grpc-client-server.md` | golang, grpc | Implement gRPC service and client; prereq: proto target fix; model after Kotlin |
 | `JAVA-001-java-grpc-client-server.md` | java, grpc | Implement gRPC service and client; model after Kotlin |
 | `PY-001-python-grpc-client-server.md` | python, grpc | Implement gRPC service and client; prereq: proto fix; model after Kotlin |


### PR DESCRIPTION
## Prerequisites
- [x] N/A

## Summary
- Add `retry.automatic` (limit: 2) to both Kotlin integration test steps (Linux + macOS) in the Buildkite pipeline
- Mitigation for intermittent socket-disconnection flakes caused by a TCP-open/gRPC-ready race on server startup (root cause tracked in CI-003)
- File ticket CI-003 for the proper fix: replace TCP readiness probe with a gRPC-level readiness check

## Validation performed
- [x] N/A — pipeline config change; no dry-run available for Buildkite

## Affected machines / services
- Buildkite CI: Kotlin integration test steps on Linux and macOS agents

## Deployment steps (POST-MERGE)
- N/A — Buildkite picks up pipeline.yml from the repo on next build

## Tickets addressed
- see #CI-003

## Rollback
- Revert commit; flake rate returns to baseline
