### PR TITLE
feat(kt): parameterize balancedBrackets with optional pairs map (KT-007 partial)

### DIFF
--- a/kotlin/src/main/kotlin/bracketskt/brackets.kt
+++ b/kotlin/src/main/kotlin/bracketskt/brackets.kt
@@ -13,17 +13,18 @@ val closedParentheses =
 val openParentheses = closedParentheses.values.toSet()
 
 @Throws()
-public fun balancedBrackets(text: String) {
+public fun balancedBrackets(text: String, pairs: Map<Char, Char> = closedParentheses) {
   if (text.isEmpty()) return // short-circuit
 
+  val opens = pairs.values.toSet()
   val stack = ArrayDeque<Char>()
   for ((i, c) in text.withIndex()) {
     when (c) {
-      in openParentheses -> {
+      in opens -> {
         stack.push(c)
       }
-      in closedParentheses -> {
-        val open = closedParentheses[c]
+      in pairs -> {
+        val open = pairs[c]
         val last =
             stack.removeLastOrNull()
                 ?: throw BracketsNotBalancedException(


### PR DESCRIPTION
## Prerequisites
- [x] N/A

## Summary
- Add optional `pairs: Map<Char, Char> = closedParentheses` parameter to `balancedBrackets`
- Internal references to module-level `closedParentheses`/`openParentheses` replaced with locals derived from `pairs`
- Zero-argument call sites (service endpoint, existing tests) unchanged — default preserves current behaviour
- No new deps, no Bazel target changes

## Validation performed
- [x] `bazel test //kotlin/...` passes (all 3 tests)

## Affected machines / services
- N/A — algorithm change only; service behaviour unchanged with default pairs

## Deployment steps (POST-MERGE)
- N/A

## Tickets addressed
- see #KT-007 (partial — algorithm parameterization only; DB wiring in later PRs)

## Rollback
- Revert commit
