### PR TITLE
feat(db): bracket_pair migration, Bazel filegroup, README, ADR-001 (DB-001)

### DIFF
--- a/db/BUILD.bazel
+++ b/db/BUILD.bazel
@@ -1,0 +1,6 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "migrations",
+    srcs = glob(["migrations/*.sql"]),
+)

--- a/db/README.md
+++ b/db/README.md
@@ -53,6 +53,7 @@ All DDL in this directory must be compatible with three parsers:
 | H2 | Build-time only — JOOQ DDLDatabase codegen (KT-005) |
 
 Safe DDL subset: `INTEGER PRIMARY KEY`, `CHAR(1)`, `BOOLEAN NOT NULL DEFAULT TRUE`.
+Note: `DEFAULT TRUE` requires SQLite >= 3.23.0 (April 2018); the `TRUE` literal was not recognized before that release.
 
 Avoid: `RETURNING`, `SERIAL`, stored procedures, `ADD COLUMN ... AFTER`, `GENERATED ALWAYS`.
 

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,63 @@
+# Database Migrations
+
+SQL migrations for the `bracket_pair` configuration table, shared between Flyway (JVM/Kotlin service) and dbmate (local dev and inspection).
+
+## External Dependency: dbmate
+
+**dbmate** is required for local migration management outside the JVM service.
+
+Install:
+```
+brew install dbmate          # macOS
+```
+Other platforms: https://github.com/amacneil/dbmate#installation
+
+This is a **pre-build requirement** for any workflow that uses dbmate directly (local dev, CI scripts that run dbmate). The Kotlin service uses Flyway internally and does not require dbmate at runtime or build time.
+
+## Filename Convention
+
+Migrations follow the timestamp format: `{YYYYMMDDHHmmss}_{description}.sql`
+
+Example: `20260421000000_create_bracket_pair.sql`
+
+This format is dbmate's native convention. Flyway is configured to match it via:
+- `sqlMigrationPrefix = ""`
+- `sqlMigrationSeparator = "_"`
+
+See `thoughts/shared/decisions/2026-04-21-migration-filename-convention.md` for the rationale.
+
+## File Structure
+
+Each migration file contains both markers:
+- `-- migrate:up` — SQL to apply (required by dbmate; Flyway runs everything in the `up` block)
+- `-- migrate:down` — intentionally empty; down migrations are not implemented in this project
+
+## Running Migrations (dbmate)
+
+```bash
+# SQLite (local dev / testing)
+DATABASE_URL="sqlite:./local.db" dbmate --migrations-dir db/migrations migrate
+
+# PostgreSQL (production)
+DATABASE_URL="postgres://user:pass@host/dbname" dbmate --migrations-dir db/migrations migrate
+```
+
+## DDL Portability
+
+All DDL in this directory must be compatible with three parsers:
+
+| Engine | Context |
+|---|---|
+| SQLite | Runtime — local dev and integration tests |
+| PostgreSQL | Runtime — production |
+| H2 | Build-time only — JOOQ DDLDatabase codegen (KT-005) |
+
+Safe DDL subset: `INTEGER PRIMARY KEY`, `CHAR(1)`, `BOOLEAN NOT NULL DEFAULT TRUE`.
+
+Avoid: `RETURNING`, `SERIAL`, stored procedures, `ADD COLUMN ... AFTER`, `GENERATED ALWAYS`.
+
+## Bazel
+
+```
+//db:migrations   — filegroup of all *.sql files; used as data= dep in the Kotlin service binary
+```

--- a/db/migrations/20260421000000_create_bracket_pair.sql
+++ b/db/migrations/20260421000000_create_bracket_pair.sql
@@ -1,0 +1,16 @@
+-- migrate:up
+
+CREATE TABLE bracket_pair (
+    id         INTEGER     NOT NULL,
+    open_char  CHAR(1)     NOT NULL,
+    close_char CHAR(1)     NOT NULL,
+    enabled    BOOLEAN     NOT NULL DEFAULT TRUE,
+    PRIMARY KEY (id)
+);
+
+INSERT INTO bracket_pair (id, open_char, close_char) VALUES (1, '(', ')');
+INSERT INTO bracket_pair (id, open_char, close_char) VALUES (2, '{', '}');
+INSERT INTO bracket_pair (id, open_char, close_char) VALUES (3, '[', ']');
+
+-- migrate:down
+-- Down migrations are intentionally not implemented in this project.

--- a/thoughts/shared/decisions/2026-04-21-migration-filename-convention.md
+++ b/thoughts/shared/decisions/2026-04-21-migration-filename-convention.md
@@ -1,0 +1,37 @@
+---
+id: ADR-001
+title: Migration filename convention — timestamp prefix, shared file for Flyway and dbmate
+status: accepted
+date: 2026-04-21
+---
+
+## Context
+
+The project needs a migration tooling strategy that works for both JVM (Flyway, used by the Kotlin service) and non-JVM contexts (dbmate, used for local development and inspection). Both tools must be able to run the same `.sql` files.
+
+Flyway defaults to `V{version}__{description}.sql` (prefix `V`, double-underscore separator).
+dbmate defaults to `{timestamp}_{description}.sql` (timestamp version, single underscore).
+
+The files need to satisfy both parsers. Three options were considered:
+
+1. **Flyway default naming** (`V1__create_bracket_pair.sql`) — dbmate cannot parse this without custom config.
+2. **Separate files per tool** — duplication, drift risk.
+3. **Timestamp naming with Flyway custom config** — Flyway supports `sqlMigrationPrefix=""` and `sqlMigrationSeparator="_"`; dbmate uses this format natively.
+
+## Decision
+
+Use timestamp-based filenames (`{YYYYMMDDHHmmss}_{description}.sql`) and configure Flyway with:
+- `sqlMigrationPrefix = ""`
+- `sqlMigrationSeparator = "_"`
+
+Both tools operate on the same files in `db/migrations/`.
+
+Include both `-- migrate:up` and `-- migrate:down` markers in every file. Flyway ignores these as SQL comments. dbmate requires the `-- migrate:down` marker (even if the block is empty); down migrations are intentionally not implemented — the block is left empty with a comment.
+
+## Consequences
+
+- Single source of truth: one file per migration, used by both tools.
+- Flyway configuration must explicitly set `sqlMigrationPrefix` and `sqlMigrationSeparator` in `DatabaseModule` (KT-006).
+- dbmate validated on the initial migration: `Applied: 20260421000000_create_bracket_pair.sql`.
+- The empty `-- migrate:down` block is a documentation convention — no rollback SQL is written.
+- DBA agent (pre-PR-3) should review and confirm this decision holds for more complex future migrations.


### PR DESCRIPTION
## Prerequisites
- [x] N/A

## Summary
- Create `db/migrations/20260421000000_create_bracket_pair.sql` — `bracket_pair` table DDL + 3 seed rows
- `db/BUILD.bazel` — `//db:migrations` filegroup (used as `data=` dep in the Kotlin service binary)
- `db/README.md` — dual-tool usage, filename convention, DDL portability constraints, dbmate as external dependency with install instructions
- `thoughts/shared/decisions/2026-04-21-migration-filename-convention.md` — ADR-001 documenting timestamp-prefix convention and Flyway/dbmate shared-file strategy
- Validated with dbmate against SQLite: migration applies cleanly, seed data present

## External dependency added: dbmate

`brew install dbmate` required for local dev migration management. Documented in `db/README.md`. Not required for Bazel build or Kotlin service runtime (Flyway handles JVM-side).

## Validation performed
- [x] `bazel build //db:migrations` passes
- [x] `DATABASE_URL="sqlite:..." dbmate migrate` applies cleanly; seed rows present

## Affected machines / services
- Local dev: dbmate install required (see README)
- Kotlin service (KT-006): will consume `//db:migrations` via Flyway; Flyway must be configured with `sqlMigrationPrefix=""` and `sqlMigrationSeparator="_"` (noted in ADR-001)

## Deployment steps (POST-MERGE)
- N/A — migration will be applied by Flyway on service startup (KT-006)

## Tickets addressed
- see #DB-001

## Rollback
- Revert commit; drop `bracket_pair` table manually if already applied
