### PR TITLE
docs: update DB feature plan — H2 for tests, ADR logging in agent prompts

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -74,6 +74,10 @@ steps:
 
   - label: ":go: Go exec via Bazel (Linux)"
     depends_on: test-linux
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 2
     plugins:
       - docker#v5.11.0:
           image: "local/ci-agent:latest"
@@ -119,6 +123,10 @@ steps:
 
   - label: ":go: Go exec via Bazel (macOS)"
     depends_on: test-macos
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 2
     agents:
       os: macos
     command: bazel run --config=ci //golang/cmd/brackets

--- a/thoughts/shared/plans/2026-04-21-db-kotlin-feature.compressed.md
+++ b/thoughts/shared/plans/2026-04-21-db-kotlin-feature.compressed.md
@@ -26,7 +26,7 @@ PR-3–PR-5: four-agent workflow (DBA↔Architect[design phase]→TDD Designer�
 
 §CONSTRAINTS
 DDL must satisfy THREE parsers:
-  SQLite(runtime local/test) | PostgreSQL(runtime prod) | H2(build-time; DDLDatabase uses H2)
+  SQLite(runtime local dev) | PostgreSQL(runtime prod) | H2(build-time codegen + test-time in-memory DB)
 safe: INTEGER PRIMARY KEY; CHAR(1); BOOLEAN NOT NULL DEFAULT TRUE
 avoid: RETURNING; SERIAL; stored procs; ADD COLUMN...AFTER; GENERATED ALWAYS
 
@@ -56,11 +56,13 @@ CONSTRAINTS BY ROLE:
       applies to .md output docs only — .sql and other non-prose files have NO compressed form
       must produce both .md + .compressed.md for research output doc
     shell-safety: never inline non-trivial text in shell cmds; write to /tmp/polyglot-<purpose>-<ctx>.txt first
+    ADR logging: decisions with meaningful tradeoffs not in research doc → thoughts/shared/decisions/YYYY-MM-DD-<slug>.md
   TDD Designer + Coder:
     VCS: jj only; never run git
     build: bazel (not bazelisk)
     style: ktfmt all modified .kt files before work is done
     shell-safety: same as above
+    ADR logging: non-obvious decisions not captured in tests/comments → thoughts/shared/decisions/YYYY-MM-DD-<slug>.md
 
 DBA PROMPT:
   Constraints: compressed-format + shell-safety (see above)
@@ -76,11 +78,12 @@ DBA PROMPT:
     2. Migration filename convention: validate Flyway empty-prefix+single-_ approach;
        produce validated conclusion (works or fallback) with evidence
     3. Seed data strategy: INSERT in migration vs. separate mechanism;
-       can tests reset/override seed data cleanly with in-memory SQLite?
+       can tests reset/override seed data cleanly with H2 in-memory?
     4. Future schema evolution: what changes are plausible? does initial schema foreclose any?
        don't over-engineer — just avoid unnecessary dead ends
     5. dbmate compatibility: confirm -- migrate:up (no down) works for both tools on same file
-    6. Test data strategy: in-memory SQLite per test; schema+seed via Flyway; no shared state
+    6. Test data strategy: H2 in-memory (jdbc:h2:mem:...) per test; schema via Flyway; test data in setup; no shared state
+       H2 already required for JOOQ codegen — avoids adding sqlite-jdbc to test scope
     7. Bazel filegroup: //db:migrations glob sufficient? any edge cases?
   Output: thoughts/shared/research/2026-04-21-db-schema-design.md + .compressed.md
   Mark each decision: fixed (others must not deviate) | provisional (open to Architect/impl refinement)
@@ -115,6 +118,7 @@ ARCHITECT PROMPT:
     5. Coroutine readiness: JOOQ blocking; describe how repository boundary contains future async migration
     6. Test surfaces per layer: unit vs integration; kinds of doubles needed; test Dagger modules
        keep at "fake in-memory impl of repository interface" level — TDD Designer writes the actual fake
+       integration tests use H2 in-memory (not SQLite; H2 already required for JOOQ codegen)
     7. Explicitly deferred: list what TDD Designer decides; flag what must be settled now vs. later
   Output: thoughts/shared/research/$arch.md + .compressed.md
   Write at responsibility+constraint level — NOT method-signature level
@@ -145,7 +149,7 @@ TDD-DESIGNER PROMPT:
   Cover:
     Repository contract: enabled pairs loaded; disabled ignored; empty→no crash; close→open direction
     Service layer: known pairs→correct result(no DB); empty→error response; unbalanced→correct error; unknown chars=plain text
-    Dagger wiring: test graph with in-memory SQLite; repository injectable; disable-pair end-to-end
+    Dagger wiring: test graph with H2 in-memory (jdbc:h2:mem:...); repository injectable; disable-pair end-to-end
   When done: tell Coder — files written; interfaces+types defined; TODO() bodies for them to fill;
     decisions that extend/deviate from Architect doc (so Coder understands full contract)
   Coder must not change your type/interface/sig definitions without your agreement; escalate to Architect if unresolved
@@ -172,7 +176,7 @@ CODER PROMPT:
     TDD Designer agrees → make change; disagree → escalate to Architect
     impossible test = reason to propose a change; bring to TDD Designer with explanation; never silent change
     Bazel: kt_jvm_library; java_binary+runtime_deps; associates=[...]; new deps → mm maven.install
-    H2 NOT in service runtime_deps (build-time only)
+    H2: build-time(codegen) + test-time(in-memory DB); NOT in service runtime_deps
     Flyway: filesystem: location + RUNFILES_DIR resolution (see plan PR-4)
     JOOQ genrule outs: exhaustive; run codegen locally once first to discover all files
   Per PR(3,4,5 in order): read design docs+tests → implement → bazel test //kotlin/... passes → ktfmt → report deviations
@@ -203,7 +207,7 @@ PRE-PR-3: design phase [DBA first in this project; Architect reads DBA output; s
 
 PR-3 KT-005 branch:kt-005-jooq-codegen prereq:DB-001 agents:TDD Designer→Coder [consult DBA+Architect]
   new mm: org.jooq:jooq:3.19.x; jooq-kotlin:3.19.x; jooq-meta-extensions:3.19.x[codegen];
-          jooq-codegen:3.19.x[codegen]; com.h2database:h2:2.x.x[build-time only]
+          jooq-codegen:3.19.x[codegen]; com.h2database:h2:2.x.x[codegen+test; not service runtime]
   codegen runner: JooqCodegenRunner(DDL path, out dir) → GenerationTool.generate()
     Database=DDLDatabase; pkg=com.geekinasuit.polyglot.brackets.db.jooq
   Bazel: java_binary(jooq_codegen_runner) → genrule(jooq_generated_srcs;outs exhaustive) →
@@ -220,7 +224,7 @@ PR-4 KT-006 branch:kt-006-database-adapter prereq:DB-001 [parallel with PR-3] ag
   FLYWAY GOTCHA: filesystem: location; Paths.get(RUNFILES_DIR?:".", "_main/db/migrations")
   wire DatabaseModule into ApplicationGraph
   Bazel: //db:migrations → data= of brackets_service; runtime deps in service BUILD.bazel
-  tests: TestApplicationGraph with in-memory SQLite; existing tests pass
+  tests: TestApplicationGraph with H2 in-memory (jdbc:h2:mem:test); existing tests pass
   accept: bazel test //kotlin/... passes; Flyway runs on startup
 
 PR-5 KT-007(remainder) branch:kt-007-bracket-config prereqs:PR-1+KT-005+KT-006 agents:TDD Designer→Coder [consult DBA+Architect]
@@ -230,10 +234,10 @@ PR-5 KT-007(remainder) branch:kt-007-bracket-config prereqs:PR-1+KT-005+KT-006 a
   Dagger: BracketConfigModule provides Map<Char,Char> @ApplicationScope from repo.loadEnabledPairs()
   BalanceServiceEndpoint: inject Map<Char,Char>; pass to balancedBrackets; empty→error response
   tests:
-    BracketPairRepositoryTest: in-memory SQLite; migration; assert loadEnabledPairs
+    BracketPairRepositoryTest: H2 in-memory (jdbc:h2:mem:...); migration; assert loadEnabledPairs
     BalanceServiceEndpointTest: known pair map; no DB
     disable-pair test: () disabled→treated as plain text
-    ApplicationGraphTest: DatabaseConfig in-memory SQLite; full graph builds
+    ApplicationGraphTest: DatabaseConfig H2 in-memory; full graph builds
   Bazel: kt_jvm_library for db pkg; add to service_lib deps
   accept: bazel test //kotlin/... passes; disable-pair test passes
 

--- a/thoughts/shared/plans/2026-04-21-db-kotlin-feature.md
+++ b/thoughts/shared/plans/2026-04-21-db-kotlin-feature.md
@@ -48,9 +48,9 @@ four-agent workflow described below.
 ### DDL / schema constraints
 
 All DDL must be compatible with three parsers:
-- **SQLite** — runtime (local dev, tests)
+- **SQLite** — runtime (local dev)
 - **PostgreSQL** — runtime (production)
-- **H2** — build time only (JOOQ DDLDatabase uses H2 to parse DDL during codegen)
+- **H2** — build time (JOOQ DDLDatabase) and test time (in-memory DB for fast, hermetic tests)
 
 `INTEGER PRIMARY KEY`, `CHAR(1)`, `BOOLEAN NOT NULL DEFAULT TRUE` are safe across all three.
 Avoid: `RETURNING`, `SERIAL`, stored procedures, `ADD COLUMN ... AFTER`, `GENERATED ALWAYS`.
@@ -153,8 +153,11 @@ This is the exception; in a greenfield feature the Architect would run first.
 >    section) works correctly for both dbmate and Flyway on the same file.
 >
 > 6. **Test data strategy:** How do integration tests get a clean, reproducible DB state?
->    Propose the pattern (e.g. in-memory SQLite per test class, schema applied via Flyway,
->    seed data inserted in test setup). No shared mutable state between tests.
+>    Use H2 in-memory (`jdbc:h2:mem:...`) as the test database — not SQLite. H2 is already a
+>    required dep for JOOQ codegen, avoids adding SQLite-jdbc to test scope, and gives faster
+>    hermetic tests without file-system state. Propose the pattern: H2 in-memory per test class,
+>    schema applied via Flyway (using the same migration files), test-specific data inserted in
+>    test setup. No shared mutable state between tests.
 >
 > 7. **Bazel filegroup:** Confirm `//db:migrations` with `glob(["migrations/*.sql"])` is
 >    sufficient. Note any edge cases (e.g. ordering, subdirectory layout).
@@ -167,6 +170,11 @@ This is the exception; in a greenfield feature the Architect would run first.
 >
 > Mark each decision as **fixed** (Architect and implementers must not deviate) or
 > **provisional** (open to refinement by the Architect or implementers with good reason).
+>
+> **ADR logging:** For any decision with meaningful tradeoffs not already captured in the
+> research doc above, write a short ADR to `thoughts/shared/decisions/YYYY-MM-DD-<slug>.md`
+> (standard format: Title, Status, Context, Decision, Consequences). Not every choice needs
+> an ADR — only those where the rationale would otherwise be invisible to a future reader.
 
 ---
 
@@ -235,7 +243,9 @@ This is the exception; in a greenfield feature the Architect would run first.
 > 6. **Test surfaces.** For each layer, describe: what is tested at unit vs. integration
 >    level? What kinds of test doubles are needed? Which Dagger modules would a test graph
 >    replace? Keep at the level of "a fake in-memory implementation of the repository
->    interface" — the TDD Designer will write the actual fake.
+>    interface" — the TDD Designer will write the actual fake. Note: integration tests use
+>    H2 in-memory (`jdbc:h2:mem:...`), not SQLite — H2 is already required for JOOQ codegen
+>    and keeps tests hermetic without file-system state.
 >
 > 7. **Explicitly deferred decisions.** List what you are deliberately leaving open for the
 >    TDD Designer. This is not a weakness — it is the handoff boundary. Be clear about which
@@ -251,6 +261,11 @@ This is the exception; in a greenfield feature the Architect would run first.
 > responsibility and constraint level — not at method-signature level. Be explicit about
 > what is fixed (TDD Designer must not deviate) versus what is deliberately open
 > (TDD Designer's domain to decide).
+>
+> **ADR logging:** For any decision with meaningful tradeoffs not already captured in the
+> research doc above, write a short ADR to `thoughts/shared/decisions/YYYY-MM-DD-<slug>.md`
+> (standard format: Title, Status, Context, Decision, Consequences). Not every choice needs
+> an ADR — only those where the rationale would otherwise be invisible to a future reader.
 
 ---
 
@@ -302,6 +317,11 @@ This is the exception; in a greenfield feature the Architect would run first.
 > - Use fakes over mocks. If a test needs a fake repository, write one — a few lines of
 >   in-memory state. Mocks couple tests to implementation details.
 > - Follow existing test patterns: JUnit 4 (`@Test`), Truth assertions.
+> - Use H2 in-memory (`jdbc:h2:mem:...`) as the database for all integration-style tests —
+>   not SQLite. H2 is already required for JOOQ codegen; using it for tests avoids an extra
+>   dep and keeps tests fully hermetic. Apply migrations via Flyway in test setup.
+> - **ADR logging:** For any tactical decision with non-obvious rationale not captured in your
+>   tests or comments, write a short ADR to `thoughts/shared/decisions/YYYY-MM-DD-<slug>.md`.
 > - If a design decision feels like it might conflict with the Architect's intent — not just
 >   fill a gap, but potentially push against a stated constraint — check with the Architect
 >   before committing to it. Don't second-guess on small tactical choices; escalate genuine
@@ -310,7 +330,8 @@ This is the exception; in a greenfield feature the Architect would run first.
 > **Cover at minimum:**
 >
 > 1. The repository contract (whatever interface/class shape you decide on):
->    - Enabled pairs loaded correctly from an in-memory SQLite DB (with migration applied)
+>    - Enabled pairs loaded correctly from an H2 in-memory DB (`jdbc:h2:mem:...`) with the
+>      migration applied via Flyway
 >    - Disabled pairs ignored
 >    - Empty DB → empty result, no crash
 >    - close→open mapping direction correct
@@ -322,7 +343,7 @@ This is the exception; in a greenfield feature the Architect would run first.
 >    - Characters not in the pair set treated as plain text
 >
 > 3. Dagger wiring:
->    - Test graph builds with in-memory SQLite `DatabaseConfig`
+>    - Test graph builds with H2 in-memory `DatabaseConfig` (`jdbc:h2:mem:...`)
 >    - Repository (or its interface) is injectable from test graph
 >    - Disabling a pair in the test DB causes that pair's characters to be accepted as plain text end-to-end
 >
@@ -386,7 +407,8 @@ This is the exception; in a greenfield feature the Architect would run first.
 > - Follow existing Bazel patterns: `kt_jvm_library` for libraries, `java_binary` +
 >   `runtime_deps` for binaries, `associates = [...]` for internal member access in tests.
 >   Add new maven deps to `MODULE.bazel` `maven.install` artifacts.
-> - Keep H2 out of service runtime deps — it is build-time only (used by JOOQ DDLDatabase).
+> - H2 is used for both JOOQ codegen (build-time) and in-memory integration tests (test-time).
+>   Keep it out of service runtime deps — it must not appear in the production binary's classpath.
 > - Flyway must use `filesystem:` location (not classpath scanning) for Bazel runfiles
 >   compatibility. See the plan for the `RUNFILES_DIR` resolution pattern.
 > - The JOOQ `genrule` `outs` list must be exhaustive. Run codegen locally once, observe
@@ -401,6 +423,11 @@ This is the exception; in a greenfield feature the Architect would run first.
 > **Escalation:** If you and the TDD Designer reach an impasse on a public contract question,
 > bring the specific conflict to the Architect with a clear question. Do not resolve it
 > unilaterally. The Coordinator can break deadlocks if the Architect cannot resolve them.
+>
+> **ADR logging:** For any implementation decision with non-obvious rationale — a library
+> call choice, an internal structure decision, a workaround — write a short ADR to
+> `thoughts/shared/decisions/YYYY-MM-DD-<slug>.md` if the reasoning would otherwise be
+> invisible to a future reader of the code.
 
 ---
 
@@ -566,7 +593,7 @@ kt_jvm_library(
 - JOOQ codegen produces Java sources (`.java`), not Kotlin — this is expected and standard
 - `jooq-kotlin` is a runtime extension (coroutine-friendly `fetchOne`, `map`, etc.); it adds
   no generated `.kt` files
-- H2 is a build-time-only dep of the runner; it must not appear in service `runtime_deps`
+- H2 is used for codegen (build-time) and tests (test-time); it must not appear in service `runtime_deps`
 - The `outs` list must be exhaustive — run codegen locally once to discover all output files
   before finalizing the genrule
 - Add all generated paths under `kotlin/` to `.gitignore` (consistent with proto codegen policy)
@@ -594,12 +621,13 @@ kt_jvm_library(
 Add `DatabaseConfig` and wire into `ServiceAppConfig`:
 ```kotlin
 data class DatabaseConfig(
-    val url: String = "jdbc:sqlite::memory:",
+    val url: String = "jdbc:sqlite::memory:", // local dev default; tests use jdbc:h2:mem:...
     val driver: String = defaultDriver(url),
     val maxPoolSize: Int = 5,
 )
 
 fun defaultDriver(url: String): String = when {
+    url.startsWith("jdbc:h2") -> "org.h2.Driver"
     url.startsWith("jdbc:sqlite") -> "org.sqlite.JDBC"
     url.startsWith("jdbc:postgresql") -> "org.postgresql.Driver"
     else -> error("Unsupported JDBC URL: $url")
@@ -670,12 +698,12 @@ Flyway.configure()
 - Add new maven runtime deps to `service_lib` in `service/BUILD.bazel`
 
 **Tests:**
-- Include `DatabaseModule` in `TestApplicationGraph` with in-memory SQLite config
+- Include `DatabaseModule` in `TestApplicationGraph` with H2 in-memory config (`jdbc:h2:mem:...`)
 - Existing `graphBuilds` and `serverProvides` tests must continue to pass
 - Verify Flyway migration runs without error on the test graph
 
 **Acceptance:** `bazel test //kotlin/...` passes; service starts; Flyway migration applies
-on startup; in-memory SQLite works in tests.
+on startup; H2 in-memory works in tests.
 
 ---
 
@@ -728,12 +756,12 @@ class BalanceServiceEndpoint @Inject constructor(
 ```
 
 **Tests:**
-- `BracketPairRepositoryTest`: in-memory SQLite `DSLContext`, apply migration via Flyway,
-  insert test rows, assert `loadEnabledPairs()` returns correct close→open map
+- `BracketPairRepositoryTest`: H2 in-memory `DSLContext` (`jdbc:h2:mem:...`), apply migration
+  via Flyway, insert test rows, assert `loadEnabledPairs()` returns correct close→open map
 - `BalanceServiceEndpointTest`: supply a known pair map as constructor arg (no DB needed)
 - Disable-pair test: insert rows with `enabled=false` for `()`, assert those characters
   are treated as plain text by the algorithm
-- `ApplicationGraphTest` updates: supply `DatabaseConfig` with in-memory SQLite so the
+- `ApplicationGraphTest` updates: supply `DatabaseConfig` with H2 in-memory URL so the
   full graph (now including `BracketConfigModule`) builds cleanly
 
 **Bazel wiring:**


### PR DESCRIPTION
## Summary

- Updates DB feature plan to use H2 in-memory database for integration tests (instead of SQLite), since H2 is already required for JOOQ DDLDatabase codegen — avoids adding sqlite-jdbc to test scope
- Adds ADR logging requirement to all agent prompts (DBA, Architect, TDD Designer, Coder): non-obvious decisions not captured in design/research docs must be written to `thoughts/shared/decisions/`
- Updates both `.md` and `.compressed.md` forms
- Also adds `retry.automatic` to Go exec via Bazel steps (Linux + macOS) to mitigate transient Bazel server crashes

## Test plan

- [x] Review plan prose for consistency (H2 referenced everywhere SQLite was for tests)
- [x] Confirm ADR logging instruction appears in DBA, Architect, TDD Designer, and Coder prompts in both files
