### PR TITLE
feat(kt): parameterize balancedBrackets with optional pairs map

### DIFF
--- a/kotlin/src/main/kotlin/bracketskt/brackets.kt
+++ b/kotlin/src/main/kotlin/bracketskt/brackets.kt
@@ -13,17 +13,18 @@ val closedParentheses =
 val openParentheses = closedParentheses.values.toSet()
 
 @Throws()
-public fun balancedBrackets(text: String) {
+public fun balancedBrackets(text: String, pairs: Map<Char, Char> = closedParentheses) {
   if (text.isEmpty()) return // short-circuit
 
+  val opens = pairs.values.toSet()
   val stack = ArrayDeque<Char>()
   for ((i, c) in text.withIndex()) {
     when (c) {
-      in openParentheses -> {
+      in opens -> {
         stack.push(c)
       }
-      in closedParentheses -> {
-        val open = closedParentheses[c]
+      in pairs -> {
+        val open = pairs[c]
         val last =
             stack.removeLastOrNull()
                 ?: throw BracketsNotBalancedException(


### PR DESCRIPTION
## Summary

- Add optional `pairs: Map<Char, Char>` parameter to `balancedBrackets` with `closedParentheses` as default
- Derive `opens` set locally from `pairs` inside the function body
- Replace references to module-level `closedParentheses`/`openParentheses` vals with the local `pairs`/`opens`

No new deps, no new Bazel targets, no config changes.

Partial implementation of KT-007 (algorithm parameterization only; DB wiring comes later in PRs 4–5).

## Test plan

- [x] `bazel test //kotlin/src/test/kotlin/bracketskt:BracketsTest` — all existing cases pass unchanged
- [x] `bazel test //kotlin/...` — no regressions across all Kotlin tests
- [x] `ktfmt` applied to changed file

see #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)
