### PR TITLE
feat(db): migration tooling and initial bracket_pair schema (DB-001)

### DIFF
--- a/db/BUILD.bazel
+++ b/db/BUILD.bazel
@@ -1,0 +1,5 @@
+filegroup(
+    name = "migrations",
+    srcs = glob(["migrations/*.sql"]),
+    visibility = ["//visibility:public"],
+)

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,87 @@
+# db — Database Migrations
+
+This directory contains SQL migration files for the `bracket_pair` schema.
+
+## Dual-tool strategy
+
+Two migration tools are in use:
+
+| Tool | Context | Why |
+|---|---|---|
+| **Flyway** | JVM runtime (Kotlin service startup) | Embedded in the service; runs migrations on startup via Dagger `DatabaseModule` |
+| **dbmate** | Non-JVM local dev and CI | Standalone binary; works without a JVM |
+
+Both tools read the same SQL files in `migrations/`.
+
+## File format
+
+Each migration file contains a `-- migrate:up` section for the forward migration.
+A `-- migrate:down` marker is present but empty — rollbacks are done via new forward
+migrations, not reversals.
+
+```sql
+-- migrate:up
+CREATE TABLE ...;
+
+-- migrate:down
+```
+
+The `-- migrate:up` marker is required by dbmate; Flyway ignores it as a SQL comment.
+The empty `-- migrate:down` satisfies dbmate's requirement that a down block exists.
+Flyway also ignores the down marker as a comment.
+
+## Filename convention
+
+Files use a timestamp-based naming convention:
+
+```
+YYYYMMDDHHMMSS_description.sql
+```
+
+Example: `20260421000000_create_bracket_pair.sql`
+
+**Flyway configuration required** (applied in `DatabaseModule`):
+
+```kotlin
+Flyway.configure()
+    .sqlMigrationPrefix("")      // no "V" prefix
+    .sqlMigrationSeparator("_")  // single underscore separates version from description
+    ...
+```
+
+This was validated: Flyway 10.x accepts timestamp filenames with these settings,
+parsing `20260421000000_create_bracket_pair.sql` as version `20260421000000`,
+description `create bracket pair`.
+
+**dbmate** accepts this format natively — it expects `YYYYMMDDHHMMSS_description.sql`.
+
+## Portability constraints
+
+All DDL must be compatible with three parsers:
+
+| Database | Usage |
+|---|---|
+| **SQLite** | Runtime — local dev default |
+| **PostgreSQL** | Runtime — production |
+| **H2** | Build time (JOOQ DDLDatabase) and test time (in-memory, hermetic tests) |
+
+**Safe column types:** `INTEGER PRIMARY KEY`, `CHAR(1)`, `BOOLEAN NOT NULL DEFAULT TRUE`
+
+**Avoid:** `RETURNING`, `SERIAL`, stored procedures, `ADD COLUMN ... AFTER`,
+`GENERATED ALWAYS AS`, `ON CONFLICT` (PostgreSQL-only syntax).
+
+## Bazel
+
+The `//db:migrations` filegroup exposes all migration files as Bazel data dependencies:
+
+```python
+# db/BUILD.bazel
+filegroup(
+    name = "migrations",
+    srcs = glob(["migrations/*.sql"]),
+    visibility = ["//visibility:public"],
+)
+```
+
+Add `//db:migrations` to the `data` attribute of any Bazel target that needs the
+migrations at runtime (e.g. the service binary, integration tests).

--- a/db/migrations/20260421000000_create_bracket_pair.sql
+++ b/db/migrations/20260421000000_create_bracket_pair.sql
@@ -1,0 +1,13 @@
+-- migrate:up
+CREATE TABLE bracket_pair (
+    id         INTEGER  PRIMARY KEY,
+    open_char  CHAR(1)  NOT NULL,
+    close_char CHAR(1)  NOT NULL,
+    enabled    BOOLEAN  NOT NULL DEFAULT TRUE
+);
+
+INSERT INTO bracket_pair (id, open_char, close_char) VALUES (1, '(', ')');
+INSERT INTO bracket_pair (id, open_char, close_char) VALUES (2, '[', ']');
+INSERT INTO bracket_pair (id, open_char, close_char) VALUES (3, '{', '}');
+
+-- migrate:down

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS "schema_migrations" (version varchar(128) primary key);
+CREATE TABLE bracket_pair (
+    id         INTEGER  PRIMARY KEY,
+    open_char  CHAR(1)  NOT NULL,
+    close_char CHAR(1)  NOT NULL,
+    enabled    BOOLEAN  NOT NULL DEFAULT TRUE
+);
+-- Dbmate schema migrations
+INSERT INTO "schema_migrations" (version) VALUES
+  ('20260421000000');


### PR DESCRIPTION
## Summary

- Create `db/migrations/20260421000000_create_bracket_pair.sql` with the initial `bracket_pair` table and seed data for the three standard bracket pairs
- Add `db/BUILD.bazel` with `//db:migrations` filegroup (`glob(["migrations/*.sql"])`)
- Add `db/README.md` documenting the dual-tool strategy, filename convention, and portability constraints

## Validation

**Flyway filename convention:** Validated that `sqlMigrationPrefix=""` + `sqlMigrationSeparator="_"` correctly parses `20260421000000_create_bracket_pair.sql` as version `20260421000000` (tested with Flyway 10.x + H2 in-memory via kotlin-main-kts).

**dbmate:** Requires a `-- migrate:down` block to exist (even empty). The file includes an empty `-- migrate:down` section, which satisfies dbmate while Flyway treats it as a comment. Both tools applied the migration successfully.

**Bazel:** `bazel build //db:migrations` passes.

## Schema

```sql
CREATE TABLE bracket_pair (
    id         INTEGER  PRIMARY KEY,
    open_char  CHAR(1)  NOT NULL,
    close_char CHAR(1)  NOT NULL,
    enabled    BOOLEAN  NOT NULL DEFAULT TRUE
);
```

Column types are portable across SQLite (runtime), PostgreSQL (runtime), and H2 (build-time + test-time).

## Test plan

- [x] Flyway 10.x applies migration against H2 in-memory — 1 migration, version `20260421000000`
- [x] dbmate 2.32 applies migration against SQLite — file accepted with empty down block
- [x] `bazel build //db:migrations` passes

see #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)
