### PR TITLE
ci: add retry.automatic to all Buildkite pipeline steps

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,6 +26,10 @@ steps:
 
   - label: ":bazel: Build (Linux)"
     key: build-linux
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 2
     plugins:
       - docker#v5.11.0:
           image: "local/ci-agent:latest"
@@ -39,6 +43,10 @@ steps:
 
   - label: ":apple: Build (macOS)"
     key: build-macos
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 2
     agents:
       os: macos
     command: bazel build --config=ci //...
@@ -50,6 +58,10 @@ steps:
   - label: ":bazel: Test (Linux)"
     key: test-linux
     depends_on: build-linux
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 2
     plugins:
       - docker#v5.11.0:
           image: "local/ci-agent:latest"
@@ -64,6 +76,10 @@ steps:
   - label: ":apple: Test (macOS)"
     key: test-macos
     depends_on: build-macos
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 2
     agents:
       os: macos
     command: bazel test --config=ci //...
@@ -91,6 +107,10 @@ steps:
 
   - label: ":go: Go exec via Make (Linux)"
     depends_on: test-linux
+    retry:
+      automatic:
+        - exit_status: "*"
+          limit: 2
     plugins:
       - docker#v5.11.0:
           image: "local/ci-agent:latest"


### PR DESCRIPTION
## Prerequisites
- [x] N/A

## Summary
- Add `retry: automatic` (limit: 2) to all Buildkite pipeline steps that were missing it: `build-linux`, `build-macos`, `test-linux`, `test-macos`, and `go-exec-make-linux`
- Motivated by a JVM crash (error code 14, "Socket closed") on the Linux build agent that failed PR #46 — an infrastructure flake with no retry path

## Validation performed
- [x] N/A — config-only change; no code modified

## Affected machines / services
- Buildkite CI pipeline only

## Deployment steps (POST-MERGE)
- Automatic — Buildkite reads pipeline.yml from the branch on each run

## Tickets addressed
- see #CI-003 (root-cause fix for Linux infra flakes)

## Rollback
- Revert this commit; the retry blocks are additive and have no other side effects
