### PR TITLE
feat(kt): DB-backed bracket config — repository, endpoint wiring, telemetry (KT-007)

### DIFF
--- a/kotlin/BUILD.bazel
+++ b/kotlin/BUILD.bazel
@@ -15,22 +15,13 @@ kt_jvm_grpc_library(
     deps = [":balance_proto_gen"],
 )
 
-# Codegen runner library
-kt_jvm_library(
-    name = "jooq_codegen_runner_lib",
-    srcs = ["src/main/kotlin/com/geekinasuit/polyglot/brackets/db/codegen/JooqCodegenRunner.kt"],
-    deps = [
-        "@maven//:org_jooq_jooq_codegen",
-        "@maven//:org_jooq_jooq_meta_extensions",
-        "@maven//:com_h2database_h2",
-    ],
-)
-
 # Codegen runner binary
 java_binary(
     name = "jooq_codegen_runner",
     main_class = "com.geekinasuit.polyglot.brackets.db.codegen.JooqCodegenRunnerKt",
-    runtime_deps = [":jooq_codegen_runner_lib"],
+    runtime_deps = [
+        "//kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/db/codegen:jooq_codegen_runner_lib",
+    ],
 )
 
 # JOOQ generates exactly these files for the current schema (verified against DDLDatabase output

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/db/BUILD.bazel
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/db/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+kt_jvm_library(
+    name = "db_lib",
+    srcs = glob(["*.kt"]),
+    plugins = [
+        "@dagger-grpc//third_party/dagger:dagger-compiler",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//kotlin:jooq_db_lib",
+        "@dagger-grpc//api",
+        "@maven//:com_google_dagger_dagger",
+        "@maven//:javax_inject_javax_inject",
+        "@maven//:org_jooq_jooq",
+    ],
+)

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/db/BracketPairRepository.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/db/BracketPairRepository.kt
@@ -1,0 +1,21 @@
+package com.geekinasuit.polyglot.brackets.db
+
+import com.geekinasuit.daggergrpc.api.ApplicationScope
+import com.geekinasuit.polyglot.brackets.db.jooq.Tables.BRACKET_PAIR
+import javax.inject.Inject
+import org.jooq.DSLContext
+
+interface BracketPairRepository {
+  fun loadEnabledPairs(): Map<Char, Char>
+}
+
+@ApplicationScope
+class BracketPairRepositoryImpl @Inject constructor(private val dsl: DSLContext) :
+    BracketPairRepository {
+  override fun loadEnabledPairs(): Map<Char, Char> =
+      dsl
+          .selectFrom(BRACKET_PAIR)
+          .where(BRACKET_PAIR.ENABLED.isTrue)
+          .fetch()
+          .associate { record -> record[BRACKET_PAIR.CLOSE_CHAR]!![0] to record[BRACKET_PAIR.OPEN_CHAR]!![0] }
+}

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/db/BracketsDbModule.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/db/BracketsDbModule.kt
@@ -1,0 +1,12 @@
+package com.geekinasuit.polyglot.brackets.db
+
+import com.geekinasuit.daggergrpc.api.ApplicationScope
+import dagger.Binds
+import dagger.Module
+
+@Module
+abstract class BracketsDbModule {
+  @Binds
+  @ApplicationScope
+  abstract fun bindBracketPairRepository(impl: BracketPairRepositoryImpl): BracketPairRepository
+}

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/db/codegen/BUILD.bazel
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/db/codegen/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+kt_jvm_library(
+    name = "jooq_codegen_runner_lib",
+    srcs = ["JooqCodegenRunner.kt"],
+    visibility = ["//kotlin:__pkg__"],
+    deps = [
+        "@maven//:com_h2database_h2",
+        "@maven//:org_jooq_jooq_codegen",
+        "@maven//:org_jooq_jooq_meta_extensions",
+    ],
+)

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BUILD.bazel
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BUILD.bazel
@@ -13,6 +13,7 @@ kt_jvm_library(
         "//kotlin:balance_grpc_gen",
         "//kotlin/src/main/kotlin/bracketskt",
         "//kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config:config_lib",
+        "//kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/db:db_lib",
         "//kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/telemetry:telemetry_lib",
         "@dagger-grpc//api",
         "@dagger-grpc//util/armeria",

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BalanceServiceEndpoint.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BalanceServiceEndpoint.kt
@@ -2,45 +2,33 @@ package com.geekinasuit.polyglot.brackets.service
 
 import bracketskt.BracketsNotBalancedException
 import bracketskt.balancedBrackets
-import com.geekinasuit.daggergrpc.api.ApplicationScope
+import com.geekinasuit.daggergrpc.api.GrpcCallScope
 import com.geekinasuit.daggergrpc.api.GrpcServiceHandler
 import com.geekinasuit.polyglot.brackets.service.protos.BalanceBracketsGrpc
 import com.geekinasuit.polyglot.brackets.service.protos.BalanceRequest
 import com.geekinasuit.polyglot.brackets.service.protos.BalanceResponse
 import com.geekinasuit.polyglot.brackets.telemetry.attributes
-import com.geekinasuit.polyglot.brackets.telemetry.counter
-import com.geekinasuit.polyglot.brackets.telemetry.longHistogram
 import com.geekinasuit.polyglot.brackets.telemetry.span
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.grpc.stub.StreamObserver
-import io.opentelemetry.api.OpenTelemetry
-import io.opentelemetry.api.metrics.LongCounter
-import io.opentelemetry.api.metrics.LongHistogram
 import io.opentelemetry.api.trace.StatusCode
-import io.opentelemetry.api.trace.Tracer
 import javax.inject.Inject
 
 private val log = KotlinLogging.logger {}
 
 @GrpcServiceHandler(BalanceBracketsGrpc::class)
-@ApplicationScope
-class BalanceServiceEndpoint @Inject constructor(otel: OpenTelemetry) :
-    BalanceBracketsGrpc.AsyncService {
-  private val tracer: Tracer = otel.getTracer("brackets-service")
-  private val meter = otel.getMeter("brackets-service")
-  private val requestCounter: LongCounter =
-      meter.counter("brackets.server.request.count") {
-        setDescription("Number of bracket balance requests")
-      }
-  private val latencyHistogram: LongHistogram =
-      meter.longHistogram("brackets.server.request.duration.ms") {
-        setDescription("Request duration in milliseconds")
-      }
+@GrpcCallScope
+class BalanceServiceEndpoint
+@Inject
+constructor(
+    private val telemetry: BracketsServiceTelemetry,
+    private val bracketPairs: Map<Char, Char>,
+) : BalanceBracketsGrpc.AsyncService {
 
   override fun balance(request: BalanceRequest, responseObserver: StreamObserver<BalanceResponse>) {
     val startMs = System.currentTimeMillis()
     val span =
-        tracer.span("balance-brackets") {
+        telemetry.tracer.span("balance-brackets") {
           setAttribute("statement.length", request.statement.length.toLong())
           setAttribute("statement.text", request.statement)
         }
@@ -49,22 +37,28 @@ class BalanceServiceEndpoint @Inject constructor(otel: OpenTelemetry) :
       span.makeCurrent().use {
         val responseBuilder = BalanceResponse.newBuilder()
         result =
-            try {
-              log.info { "Balancing brackets: length=${request.statement.length}" }
-              balancedBrackets(request.statement)
-              log.info { "Brackets are balanced." }
-              responseBuilder.setIsBalanced(true).setSucceeded(true)
-              "balanced"
-            } catch (e: BracketsNotBalancedException) {
-              log.info { "Brackets not balanced: ${e.message}" }
-              responseBuilder.setIsBalanced(false).setSucceeded(true).setError(e.message)
-              "not_balanced"
-            } catch (e: Exception) {
-              log.info { "Error balancing brackets: ${e.message}" }
-              responseBuilder.setSucceeded(false).setError(e.message)
-              span.setStatus(StatusCode.ERROR, e.message ?: "unknown error")
+            if (bracketPairs.isEmpty()) {
+              log.warn { "No bracket pairs configured; returning error." }
+              responseBuilder.setSucceeded(false).setError("No bracket pairs configured")
+              span.setStatus(StatusCode.ERROR, "No bracket pairs configured")
               "error"
-            }
+            } else
+                try {
+                  log.info { "Balancing brackets: length=${request.statement.length}" }
+                  balancedBrackets(request.statement, bracketPairs)
+                  log.info { "Brackets are balanced." }
+                  responseBuilder.setIsBalanced(true).setSucceeded(true)
+                  "balanced"
+                } catch (e: BracketsNotBalancedException) {
+                  log.info { "Brackets not balanced: ${e.message}" }
+                  responseBuilder.setIsBalanced(false).setSucceeded(true).setError(e.message)
+                  "not_balanced"
+                } catch (e: Exception) {
+                  log.info { "Error balancing brackets: ${e.message}" }
+                  responseBuilder.setSucceeded(false).setError(e.message)
+                  span.setStatus(StatusCode.ERROR, e.message ?: "unknown error")
+                  "error"
+                }
         span.setAttribute("result", result)
         responseObserver.onNext(responseBuilder.build())
         responseObserver.onCompleted()
@@ -73,8 +67,8 @@ class BalanceServiceEndpoint @Inject constructor(otel: OpenTelemetry) :
       span.end()
       val durationMs = System.currentTimeMillis() - startMs
       val attrs = attributes { put("result", result) }
-      requestCounter.add(1, attrs)
-      latencyHistogram.record(durationMs, attrs)
+      telemetry.requestCounter.add(1, attrs)
+      telemetry.latencyHistogram.record(durationMs, attrs)
     }
   }
 }

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BracketsServiceTelemetry.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BracketsServiceTelemetry.kt
@@ -1,0 +1,25 @@
+package com.geekinasuit.polyglot.brackets.service
+
+import com.geekinasuit.daggergrpc.api.ApplicationScope
+import com.geekinasuit.polyglot.brackets.telemetry.counter
+import com.geekinasuit.polyglot.brackets.telemetry.longHistogram
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.metrics.LongCounter
+import io.opentelemetry.api.metrics.LongHistogram
+import io.opentelemetry.api.trace.Tracer
+import javax.inject.Inject
+
+/** Holds application-scoped OpenTelemetry instruments for the brackets service. */
+@ApplicationScope
+class BracketsServiceTelemetry @Inject constructor(otel: OpenTelemetry) {
+  val tracer: Tracer = otel.getTracer("brackets-service")
+  private val meter = otel.getMeter("brackets-service")
+  val requestCounter: LongCounter =
+      meter.counter("brackets.server.request.count") {
+        setDescription("Number of bracket balance requests")
+      }
+  val latencyHistogram: LongHistogram =
+      meter.longHistogram("brackets.server.request.duration.ms") {
+        setDescription("Request duration in milliseconds")
+      }
+}

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/ApplicationGraph.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/ApplicationGraph.kt
@@ -2,6 +2,7 @@ package com.geekinasuit.polyglot.brackets.service.dagger
 
 import com.geekinasuit.daggergrpc.api.ApplicationScope
 import com.geekinasuit.polyglot.brackets.config.ServiceAppConfig
+import com.geekinasuit.polyglot.brackets.db.BracketsDbModule
 import com.linecorp.armeria.server.Server
 import dagger.BindsInstance
 import dagger.Component
@@ -12,6 +13,7 @@ import io.opentelemetry.api.trace.Tracer
     modules =
         [
             ApplicationGraphModule::class,
+            BracketsDbModule::class,
             DatabaseModule::class,
             GrpcHandlersModule::class,
             InterceptorsModule::class,

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/DatabaseSupport.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/DatabaseSupport.kt
@@ -9,8 +9,10 @@ import org.flywaydb.core.Flyway
 import org.jooq.SQLDialect
 
 fun createMigratedDataSource(config: DatabaseConfig): DataSource {
-  val migrationsPath =
-      Paths.get(System.getenv("RUNFILES_DIR") ?: ".", "_main/db/migrations").toAbsolutePath()
+  // RUNFILES_DIR is set by the Bazel test runner; JAVA_RUNFILES is set by the java_binary wrapper.
+  // Both point to the runfiles tree root. Fall back to "." only as a last resort.
+  val runfilesDir = System.getenv("RUNFILES_DIR") ?: System.getenv("JAVA_RUNFILES") ?: "."
+  val migrationsPath = Paths.get(runfilesDir, "_main/db/migrations").toAbsolutePath()
 
   val hikariConfig =
       HikariConfig().apply {

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/GrpcCallScopeGraphModule.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/GrpcCallScopeGraphModule.kt
@@ -1,6 +1,14 @@
 package com.geekinasuit.polyglot.brackets.service.dagger
 
 import com.geekinasuit.daggergrpc.api.GrpcCallContext
+import com.geekinasuit.daggergrpc.api.GrpcCallScope
+import com.geekinasuit.polyglot.brackets.db.BracketPairRepository
 import dagger.Module
+import dagger.Provides
 
-@Module(includes = [GrpcCallContext.Module::class]) object GrpcCallScopeGraphModule
+@Module(includes = [GrpcCallContext.Module::class])
+object GrpcCallScopeGraphModule {
+  @Provides
+  @GrpcCallScope
+  fun bracketPairs(repo: BracketPairRepository): Map<Char, Char> = repo.loadEnabledPairs()
+}

--- a/kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/db/BUILD.bazel
+++ b/kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/db/BUILD.bazel
@@ -10,3 +10,22 @@ kt_jvm_test(
         "@maven//:junit_junit",
     ],
 )
+
+kt_jvm_test(
+    name = "BracketPairRepositoryTest",
+    srcs = ["BracketPairRepositoryTest.kt"],
+    data = ["//db:migrations"],
+    test_class = "com.geekinasuit.polyglot.brackets.db.BracketPairRepositoryTest",
+    deps = [
+        "//kotlin:jooq_db_lib",
+        "//kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/db:db_lib",
+        "@maven//:com_google_truth_truth",
+        "@maven//:com_zaxxer_HikariCP",
+        "@maven//:junit_junit",
+        "@maven//:org_flywaydb_flyway_core",
+        "@maven//:org_jooq_jooq",
+    ],
+    runtime_deps = [
+        "@maven//:com_h2database_h2",
+    ],
+)

--- a/kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/db/BracketPairRepositoryTest.kt
+++ b/kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/db/BracketPairRepositoryTest.kt
@@ -1,0 +1,60 @@
+package com.geekinasuit.polyglot.brackets.db
+
+import com.geekinasuit.polyglot.brackets.db.jooq.Tables.BRACKET_PAIR
+import com.google.common.truth.Truth.assertThat
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import java.nio.file.Paths
+import java.util.UUID
+import org.flywaydb.core.Flyway
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class BracketPairRepositoryTest {
+  private lateinit var dataSource: HikariDataSource
+
+  @Before
+  fun setUp() {
+    val jdbcUrl = "jdbc:h2:mem:repo-test-${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
+    val config =
+        HikariConfig().apply {
+          this.jdbcUrl = jdbcUrl
+          maximumPoolSize = 2
+        }
+    dataSource = HikariDataSource(config)
+    val runfilesDir = System.getenv("RUNFILES_DIR") ?: System.getenv("JAVA_RUNFILES") ?: "."
+    val migrationsPath = Paths.get(runfilesDir, "_main/db/migrations").toAbsolutePath()
+    Flyway.configure()
+        .dataSource(dataSource)
+        .sqlMigrationPrefix("")
+        .sqlMigrationSeparator("_")
+        .locations("filesystem:$migrationsPath")
+        .load()
+        .migrate()
+  }
+
+  @After
+  fun tearDown() {
+    dataSource.close()
+  }
+
+  @Test
+  fun loadEnabledPairs_returnsAllEnabledRows() {
+    val dsl = DSL.using(dataSource, SQLDialect.H2)
+    val repo = BracketPairRepositoryImpl(dsl)
+    val pairs = repo.loadEnabledPairs()
+    assertThat(pairs).containsExactlyEntriesIn(mapOf(')' to '(', ']' to '[', '}' to '{'))
+  }
+
+  @Test
+  fun loadEnabledPairs_excludesDisabledRows() {
+    val dsl = DSL.using(dataSource, SQLDialect.H2)
+    dsl.update(BRACKET_PAIR).set(BRACKET_PAIR.ENABLED, false).where(BRACKET_PAIR.ID.eq(1)).execute()
+    val repo = BracketPairRepositoryImpl(dsl)
+    val pairs = repo.loadEnabledPairs()
+    assertThat(pairs).containsExactlyEntriesIn(mapOf(']' to '[', '}' to '{'))
+  }
+}

--- a/kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/service/BUILD.bazel
+++ b/kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/service/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+
+kt_jvm_test(
+    name = "BalanceServiceEndpointTest",
+    srcs = ["BalanceServiceEndpointTest.kt"],
+    associates = [
+        "//kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service:service_lib",
+    ],
+    test_class = "com.geekinasuit.polyglot.brackets.service.BalanceServiceEndpointTest",
+    deps = [
+        "//kotlin:balance_grpc_gen",
+        "@maven//:com_google_truth_truth",
+        "@maven//:io_grpc_grpc_api",
+        "@maven//:io_opentelemetry_opentelemetry_api",
+        "@maven//:junit_junit",
+    ],
+    runtime_deps = [
+        "@maven//:ch_qos_logback_logback_classic",
+        "//kotlin/src/main/resources:service_resources",
+    ],
+)

--- a/kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/service/BalanceServiceEndpointTest.kt
+++ b/kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/service/BalanceServiceEndpointTest.kt
@@ -1,0 +1,66 @@
+package com.geekinasuit.polyglot.brackets.service
+
+import com.geekinasuit.polyglot.brackets.service.protos.BalanceRequest
+import com.geekinasuit.polyglot.brackets.service.protos.BalanceResponse
+import com.google.common.truth.Truth.assertThat
+import io.grpc.stub.StreamObserver
+import io.opentelemetry.api.OpenTelemetry
+import org.junit.Test
+
+class BalanceServiceEndpointTest {
+  private val telemetry = BracketsServiceTelemetry(OpenTelemetry.noop())
+  private val defaultPairs = mapOf(')' to '(', ']' to '[', '}' to '{')
+
+  private fun endpoint(pairs: Map<Char, Char> = defaultPairs) =
+      BalanceServiceEndpoint(telemetry, pairs)
+
+  private fun balance(
+      statement: String,
+      pairs: Map<Char, Char> = defaultPairs,
+  ): BalanceResponse {
+    var response: BalanceResponse? = null
+    endpoint(pairs)
+        .balance(
+            BalanceRequest.newBuilder().setStatement(statement).build(),
+            object : StreamObserver<BalanceResponse> {
+              override fun onNext(value: BalanceResponse) {
+                response = value
+              }
+
+              override fun onError(t: Throwable) = Unit
+
+              override fun onCompleted() = Unit
+            },
+        )
+    return checkNotNull(response)
+  }
+
+  @Test
+  fun balancedInput_succeeds() {
+    val response = balance("(hello [world])")
+    assertThat(response.succeeded).isTrue()
+    assertThat(response.isBalanced).isTrue()
+  }
+
+  @Test
+  fun unbalancedInput_returnsNotBalanced() {
+    val response = balance("(hello [world)")
+    assertThat(response.succeeded).isTrue()
+    assertThat(response.isBalanced).isFalse()
+    assertThat(response.error).isNotEmpty()
+  }
+
+  @Test
+  fun emptyPairs_returnsError() {
+    val response = balance("(hello)", emptyMap())
+    assertThat(response.succeeded).isFalse()
+    assertThat(response.error).contains("No bracket pairs configured")
+  }
+
+  @Test
+  fun emptyStatement_succeeds() {
+    val response = balance("")
+    assertThat(response.succeeded).isTrue()
+    assertThat(response.isBalanced).isTrue()
+  }
+}

--- a/kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/ApplicationGraphTest.kt
+++ b/kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/ApplicationGraphTest.kt
@@ -1,5 +1,6 @@
 package com.geekinasuit.polyglot.brackets.service.dagger
 
+import com.geekinasuit.polyglot.brackets.config.DatabaseConfig
 import com.geekinasuit.polyglot.brackets.config.ServiceAppConfig
 import com.geekinasuit.polyglot.brackets.config.ServiceConfig
 import com.geekinasuit.polyglot.brackets.config.TelemetryConfig
@@ -11,6 +12,7 @@ class ApplicationGraphTest {
       ServiceAppConfig(
           service = ServiceConfig(host = "127.0.0.1", port = 0),
           telemetry = TelemetryConfig(),
+          db = DatabaseConfig(),
       )
 
   @Test
@@ -24,5 +26,14 @@ class ApplicationGraphTest {
     val graph = TestApplicationGraph.builder().config(testConfig).build()
     val server = graph.server()
     assertThat(server).isNotNull()
+  }
+
+  @Test
+  fun callScopeGraphProvides() {
+    val graph = TestApplicationGraph.builder().config(testConfig).build()
+    val callScope = graph.callScope()
+    assertThat(callScope).isNotNull()
+    val endpoint = callScope.balance()
+    assertThat(endpoint).isNotNull()
   }
 }

--- a/kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/BUILD.bazel
+++ b/kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/BUILD.bazel
@@ -13,6 +13,7 @@ kt_jvm_test(
     test_class = "com.geekinasuit.polyglot.brackets.service.dagger.ApplicationGraphTest",
     deps = [
         "//kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/config:config_lib",
+        "//kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/db:db_lib",
         "@dagger-grpc//api",
         "@maven//:com_google_dagger_dagger",
         "@maven//:com_google_truth_truth",

--- a/kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/TestApplicationGraph.kt
+++ b/kotlin/src/test/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/TestApplicationGraph.kt
@@ -2,6 +2,7 @@ package com.geekinasuit.polyglot.brackets.service.dagger
 
 import com.geekinasuit.daggergrpc.api.ApplicationScope
 import com.geekinasuit.polyglot.brackets.config.ServiceAppConfig
+import com.geekinasuit.polyglot.brackets.db.BracketsDbModule
 import com.linecorp.armeria.server.Server
 import dagger.BindsInstance
 import dagger.Component
@@ -11,6 +12,7 @@ import dagger.Component
     modules =
         [
             TestApplicationGraphModule::class,
+            BracketsDbModule::class,
             TestDatabaseModule::class,
             GrpcHandlersModule::class,
             InterceptorsModule::class,


### PR DESCRIPTION
## Prerequisites
- [x] Parent PR merged: #48 (KT-006 — database adapter)

## Summary
- Wires the `BRACKET_PAIR` database table into the gRPC service so bracket pairs are loaded from the DB on each call rather than being hard-coded.
- Extracts OTel instruments into `BracketsServiceTelemetry` (application-scoped singleton), removing inline field declarations from the endpoint.
- Changes `BalanceServiceEndpoint` from `@ApplicationScope` to `@GrpcCallScope` so it receives per-call `Map<Char, Char>` loaded from the DB via `BracketPairRepository`.
- Adds graceful error response when no pairs are configured (empty map → `succeeded=false`).
- Fixes Bazel package-boundary issue introduced by the KT-006 `db/BUILD.bazel`: moves `jooq_codegen_runner_lib` into `db/codegen/BUILD.bazel` so `kotlin/BUILD.bazel` no longer crosses the subpackage boundary.

## Validation performed
- [x] `bazel build //kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service:service_lib` — confirms `@GrpcCallScope` + `@GrpcServiceHandler` is accepted by Dagger.
- [x] `bazel test //kotlin/...` — all 6 tests pass (3 new: `BracketPairRepositoryTest`, `BalanceServiceEndpointTest`, `callScopeGraphProvides` in `ApplicationGraphTest`).

## New tests
- `BracketPairRepositoryTest` — H2 + Flyway inline, verifies enabled rows and disabled-row exclusion.
- `BalanceServiceEndpointTest` — unit test with literal map; covers balanced, unbalanced, empty-pairs, empty-statement cases.
- `ApplicationGraphTest.callScopeGraphProvides` — end-to-end graph smoke test through to the endpoint.

## Tickets addressed
- see #50 (KT-007)

## Rollback
- Revert this PR; the service falls back to the hard-coded default pairs in prior commits.
