### PR TITLE
feat(kt): bundle migrations as classpath resources for deploy-jar execution

### DIFF
--- a/db/BUILD.bazel
+++ b/db/BUILD.bazel
@@ -3,3 +3,11 @@ filegroup(
     srcs = glob(["migrations/*.sql"]),
     visibility = ["//visibility:public"],
 )
+
+# Packages migration SQL files as classpath resources at path db/migrations/*.sql,
+# so the service can locate them when running from a deploy jar (no runfiles tree).
+java_library(
+    name = "migrations_resources",
+    resources = glob(["migrations/*.sql"]),
+    visibility = ["//visibility:public"],
+)

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BUILD.bazel
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BUILD.bazel
@@ -33,6 +33,7 @@ kt_jvm_library(
         "@maven//:javax_inject_javax_inject",
     ],
     runtime_deps = [
+        "//db:migrations_resources",
         "@maven//:ch_qos_logback_logback_classic",
         "@maven//:com_h2database_h2",
         "@maven//:net_logstash_logback_logstash_logback_encoder",

--- a/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/DatabaseSupport.kt
+++ b/kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/dagger/DatabaseSupport.kt
@@ -9,10 +9,14 @@ import org.flywaydb.core.Flyway
 import org.jooq.SQLDialect
 
 fun createMigratedDataSource(config: DatabaseConfig): DataSource {
-  // RUNFILES_DIR is set by the Bazel test runner; JAVA_RUNFILES is set by the java_binary wrapper.
-  // Both point to the runfiles tree root. Fall back to "." only as a last resort.
-  val runfilesDir = System.getenv("RUNFILES_DIR") ?: System.getenv("JAVA_RUNFILES") ?: "."
-  val migrationsPath = Paths.get(runfilesDir, "_main/db/migrations").toAbsolutePath()
+  // Determine Flyway migration location based on execution context:
+  //   RUNFILES_DIR: set by the Bazel test runner
+  //   JAVA_RUNFILES: set by the java_binary shell wrapper
+  //   neither: running from a deploy jar; migrations are bundled as classpath resources
+  val migrationsLocation =
+      (System.getenv("RUNFILES_DIR") ?: System.getenv("JAVA_RUNFILES"))?.let { runfilesDir ->
+        "filesystem:${Paths.get(runfilesDir, "_main/db/migrations").toAbsolutePath()}"
+      } ?: "classpath:db/migrations"
 
   val hikariConfig =
       HikariConfig().apply {
@@ -25,7 +29,7 @@ fun createMigratedDataSource(config: DatabaseConfig): DataSource {
         .dataSource(dataSource)
         .sqlMigrationPrefix("")
         .sqlMigrationSeparator("_")
-        .locations("filesystem:$migrationsPath")
+        .locations(migrationsLocation)
         .load()
         .migrate()
   } catch (e: Exception) {


### PR DESCRIPTION
## Prerequisites
- [x] Parent PR merged: #50 (KT-007 — DB-backed bracket config)

## Summary
- When `brackets_service_deploy.jar` is executed (no Bazel runfiles tree), Flyway previously couldn't locate migrations because `RUNFILES_DIR` / `JAVA_RUNFILES` are absent outside the Bazel ecosystem.
- Adds `java_library(migrations_resources)` to `db/BUILD.bazel` that packages the migration SQL files into the jar at classpath path `db/migrations/`.
- Adds `//db:migrations_resources` to `service_lib` runtime_deps so it is included in the deploy jar.
- Updates `DatabaseSupport.createMigratedDataSource` to use `classpath:db/migrations` when no runfiles env var is present; uses `filesystem:` when running under Bazel (test runner sets `RUNFILES_DIR`; `java_binary` wrapper sets `JAVA_RUNFILES`).
- Verified: `jar tf brackets_service_deploy.jar | grep db/migrations` shows the SQL file at `db/migrations/20260421000000_create_bracket_pair.sql`.

## Validation performed
- [x] `bazel test //kotlin/...` — all 6 tests pass
- [x] `bazel build //kotlin:brackets_service_deploy.jar` — builds successfully
- [x] `jar tf` confirms migration file at `db/migrations/20260421000000_create_bracket_pair.sql` inside the jar
- [x] Integration test script passes (runfiles path still used by the wrapped binary)

## Rollback
- Revert this PR; the service falls back to the runfiles-only behavior from PR #50.
