### PR TITLE
chore: resolve tickets DB-001, KT-002, KT-005, KT-006

### DIFF
--- a/thoughts/shared/tickets/DB-001-schema-migrations-setup.md
+++ b/thoughts/shared/tickets/DB-001-schema-migrations-setup.md
@@ -2,17 +2,22 @@
 id: DB-001
 title: Schema migration tooling and initial bracket_pair schema
 area: database, migrations, cross-language
-status: open
+status: resolved
 created: 2026-04-21
+resolved_date: 2026-04-22
 ---
 
 ## Summary
 
 Establish a canonical location for SQL schema files and configure a dual-tool migration strategy: **Flyway** (embedded Java API) for JVM-based implementations, **dbmate** (single static binary, no JVM dependency) for all other languages. Both tools read the same migration files. Down migrations are omitted throughout — they are of dubious value and create cross-tool compatibility issues.
 
-## Current State
+## Resolution
 
-No SQL schema files or migration tooling exist. The bracket algorithm hardcodes its pair definitions in Kotlin source.
+`db/migrations/20260421000000_create_bracket_pair.sql` created with `bracket_pair` schema and seed data for the three standard pairs. Filename convention validated: dbmate timestamp format confirmed compatible with Flyway via `sqlMigrationPrefix=""` + `sqlMigrationSeparator="_"`. Migration files exposed as a Bazel `filegroup` (`//db:migrations`) and also bundled as classpath resources (`//db:migrations_resources`) for deploy-jar execution. Implemented in PR #43; deploy-jar classpath resource bundling added in PR #52.
+
+## Original State
+
+No SQL schema files or migration tooling existed. The bracket algorithm hardcoded its pair definitions in Kotlin source.
 
 ## Migration File Format
 

--- a/thoughts/shared/tickets/KT-002-kotlin-dagger-grpc-di.md
+++ b/thoughts/shared/tickets/KT-002-kotlin-dagger-grpc-di.md
@@ -2,13 +2,18 @@
 id: KT-002
 title: Introduce Dagger DI via dagger-grpc integration
 area: kotlin, grpc, di
-status: open
+status: resolved
 created: 2026-03-07
+resolved_date: 2026-04-22
 ---
 
 # Kotlin: Introduce Dagger DI via dagger-grpc integration
 
-## Summary
+## Resolution
+
+Dagger 2 with `dagger-grpc` introduced for the Kotlin service. `@ApplicationScope` `ApplicationGraph` `@Component` with `BracketsDbModule`, `DatabaseModule`, `GrpcHandlersModule`, `InterceptorsModule`, `TelemetryModule`, `ServerModule`. `@GrpcCallScope` subcomponent (`GrpcCallScopeGraph`) handles per-call binding. `BalanceServiceEndpoint` annotated with `@Inject` constructor. `FakeTelemetryModule` swaps in no-op OTel for tests. All wiring verified with `bazel test //kotlin/...`.
+
+## Original Summary
 
 The Kotlin service and client currently wire all objects manually (hardcoded construction
 in `run()` methods). As the project grows — particularly with the OTel telemetry subsystem,

--- a/thoughts/shared/tickets/KT-005-jooq-codegen.md
+++ b/thoughts/shared/tickets/KT-005-jooq-codegen.md
@@ -2,17 +2,22 @@
 id: KT-005
 title: JOOQ integration and DDL-based code generation for Kotlin
 area: kotlin, database, jooq, bazel
-status: open
+status: resolved
 created: 2026-04-21
+resolved_date: 2026-04-22
 ---
 
 ## Summary
 
 Add JOOQ and its Kotlin extensions to the Kotlin build, configure code generation from the Flyway DDL migration files (no live database required at build time), and integrate the codegen step into the Bazel build.
 
-## Current State
+## Resolution
 
-No JOOQ dependency exists. DB-001 will provide the schema DDL in `db/migrations/`.
+`org.jooq:jooq`, `org.jooq:jooq-kotlin`, and `org.jooq:jooq-meta-extensions` added via bzlmod `maven.install`. `JooqCodegenRunner.kt` (`//kotlin/.../db/codegen:jooq_codegen_runner_lib`) runs DDLDatabase codegen against the migration SQL at build time. Bazel `genrule` (`//kotlin:jooq_generated_srcs`) produces `Tables.java`, `tables/BracketPair.java`, `tables/records/BracketPairRecord.java`, `Keys.java`, `DefaultCatalog.java`, `DefaultSchema.java`, exposed as `//kotlin:jooq_db_lib`. Generated files are `.gitignore`d. Implemented in PR #45.
+
+## Original State
+
+No JOOQ dependency existed. DB-001 was to provide the schema DDL in `db/migrations/`.
 
 ## Prerequisites
 

--- a/thoughts/shared/tickets/KT-006-database-adapter.md
+++ b/thoughts/shared/tickets/KT-006-database-adapter.md
@@ -2,8 +2,9 @@
 id: KT-006
 title: Database adapter layer — DataSource config, connection pool, Flyway, Dagger wiring
 area: kotlin, database, dagger, configuration
-status: open
+status: resolved
 created: 2026-04-21
+resolved_date: 2026-04-22
 github_issue: 49
 ---
 
@@ -11,9 +12,13 @@ github_issue: 49
 
 Add the runtime database layer to the Kotlin service: a `DatabaseConfig` Hoplite config stanza, a HikariCP `DataSource` factory supporting SQLite (local/test) and PostgreSQL (production), automatic Flyway migration on startup, and a Dagger module that binds `DataSource` and JOOQ `DSLContext` for injection.
 
-## Current State
+## Resolution
 
-The service has Hoplite config (ServiceConfig, TelemetryConfig) and a Dagger application graph. No database wiring exists.
+`DatabaseConfig` added to `Config.kt` and wired into `ServiceAppConfig`. HikariCP `DataSource` factory in `DatabaseSupport.kt` supports SQLite (local/test) and PostgreSQL (prod), with dialect auto-detection. Flyway runs on DataSource creation; migration location resolves via `RUNFILES_DIR` → `JAVA_RUNFILES` → `classpath:db/migrations` (deploy jar fallback). `BracketsDbModule` binds `DataSource` and `DSLContext`. All deps added to `service_lib`. `bazel test //kotlin/...` passes. Implemented in PR #48; deploy-jar classpath fallback added in PR #52.
+
+## Original State
+
+The service had Hoplite config (ServiceConfig, TelemetryConfig) and a Dagger application graph. No database wiring existed.
 
 ## Prerequisites
 

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -38,16 +38,12 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 
 | File | Area | Summary |
 |---|---|---|
-| `DB-001-schema-migrations-setup.md` | database, migrations, cross-language | Flyway (JVM) + dbmate (non-JVM) dual-tool migration setup; `db/migrations/`; initial `bracket_pair` schema |
-| `KT-005-jooq-codegen.md` | kotlin, database, jooq, bazel | JOOQ + jooq-kotlin dependency + DDL-based codegen + Bazel genrule; prereq: DB-001 |
-| `KT-006-database-adapter.md` | kotlin, database, dagger, configuration | HikariCP DataSource, Flyway on startup, Dagger DatabaseModule, SQLite/PG support; prereq: DB-001 |
 | `KT-004-kotlin-docker-deployment.md` | kotlin, docker, deployment | Docker container build for Kotlin service; staging + production profiles |
 | `CI-001-github-action-ticket-close-sync.md` | automation, github, tickets | GitHub Action safety net: sync ticket state when issue is closed without a PR ticket update |
 | `BUILD-001-grpc-kotlin-bzlmod-migration.md` | kotlin, bazel, grpc | Migrate to bzlmod-native `grpc_kotlin` when upstream supports it |
 | `GO-002-go-grpc-library-wrong-proto-target.md` | golang, bazel | `go_grpc_library` wraps wrong proto (`//protobuf` → should be `//protobuf:balance_rpc`) |
 | `PY-002-python-proto-integration-incomplete.md` | python, protobuf | Proto import disabled; `foo()` returns `None` |
 | `KT-001-kotlin-grpc-interceptors-not-implemented.md` | kotlin, grpc | `wrapService()` interceptor hook exists but no interceptors implemented |
-| `KT-002-kotlin-dagger-grpc-di.md` | kotlin, grpc, di | Introduce Dagger 2 DI for the Kotlin service via dagger-grpc |
 | `KT-003-kotlin-dagger-client-di.md` | kotlin, grpc, di | Dagger DI for the gRPC client binary; prereq: server DI ticket |
 | `CI-002-cross-language-e2e-matrix.md` | testing, ci, grpc, multi-language | Matrix test for every (client lang) × (server lang) combination; prereq: all gRPC client+server tickets |
 | `CI-003-integration-test-grpc-readiness-probe.md` | ci, testing, kotlin | Replace TCP readiness check with gRPC-level probe; root cause of socket-disconnection flakes on startup |
@@ -64,5 +60,9 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 | Summary | Resolution |
 |---|---|
 | KT-007: DB-backed bracket config | Implemented: `BracketPairRepository` (JOOQ), `BracketsDbModule`, `BracketsServiceTelemetry`, `@GrpcCallScope` endpoint wiring, tests; merged in PR #50 |
+| KT-002: Dagger 2 DI via dagger-grpc | `ApplicationGraph` @Component, `GrpcCallScopeGraph` subcomponent, all service modules, `@Inject` constructors |
+| KT-005: JOOQ codegen | `JooqCodegenRunner`, Bazel genrule + `jooq_db_lib`, DDLDatabase codegen from migration SQL, generated files gitignored; merged in PR #45 |
+| KT-006: Database adapter layer | `DatabaseConfig`, HikariCP + Flyway + JOOQ `DSLContext` wiring, `BracketsDbModule`, runfiles+classpath migration resolution; merged in PR #48 and #52 |
+| DB-001: Schema migrations and tooling | `db/migrations/20260421000000_create_bracket_pair.sql`, dbmate+Flyway compatible format, Bazel filegroup + classpath resource targets; merged in PR #43 and #52 |
 | Machine-specific cache config in repo `.bazelrc` | Resolved directly: `--disk_cache` and `--remote_cache` lines removed from `.bazelrc`; developers configure cache in `user.bazelrc` (gitignored) or `~/.bazelrc` |
 | Buildkite CI pipeline (issue #13, PR #14) | Implemented pipeline mirroring GitHub Actions: Linux steps via Docker plugin, macOS steps on native agent (`os=macos`). Fixes during stabilization: cluster assignment, arch-aware bazelisk download, `build-essential` for `rules_cc`, Go image bumped to 1.25, `$$`-escaped Buildkite variable interpolation in Docker command blocks. |


### PR DESCRIPTION
## Summary

Mark four completed tickets as resolved in ticket files and TICKETS.md. All work was implemented and merged in prior PRs; the ticket statuses were not updated at the time.

- **DB-001** — `db/migrations/20260421000000_create_bracket_pair.sql` created, Flyway+dbmate compatible format validated, Bazel `filegroup` + `migrations_resources` targets added. Implemented in PRs #43 and #52.
- **KT-002** — Dagger 2 DI via `dagger-grpc` fully wired for the service: `ApplicationGraph` `@Component`, `GrpcCallScopeGraph` subcomponent, all modules, `@Inject` constructors. Specific merged PR not identified in history (PR #27 was closed without merge); code confirmed present and tested.
- **KT-005** — JOOQ DDL-based codegen: `JooqCodegenRunner`, Bazel genrule producing `jooq_db_lib`, generated files gitignored. Implemented in PR #45.
- **KT-006** — Database adapter layer: `DatabaseConfig`, HikariCP + Flyway + JOOQ `DSLContext`, `BracketsDbModule`, runfiles→classpath migration location fallback. Implemented in PRs #48 and #52.

## Changes

- `thoughts/shared/tickets/TICKETS.md` — moved four rows from Open to Resolved
- `DB-001-schema-migrations-setup.md` — status: resolved, resolution note added
- `KT-002-kotlin-dagger-grpc-di.md` — status: resolved, resolution note added
- `KT-005-jooq-codegen.md` — status: resolved, resolution note added
- `KT-006-database-adapter.md` — status: resolved, resolution note added

## Test plan

- No code changes — ticket bookkeeping only.
