### PR TITLE
Add Python parity tickets and implementation plan

### DIFF
--- a/thoughts/shared/plans/2026-04-25-python-parity-implementation-plan.compressed.md
+++ b/thoughts/shared/plans/2026-04-25-python-parity-implementation-plan.compressed.md
@@ -1,0 +1,49 @@
+<!--COMPRESSED v1; source:2026-04-25-python-parity-implementation-plan.md-->
+§META
+date:2026-04-25 author:Qwen Code ticket:PY-001 status:draft
+
+§GOAL
+parity: Python full feature match to Kotlin reference; Python norms for libs, async, CLI, logging, telemetry
+
+§CONTEXT
+Python: core algo+tests; missing: gRPC svc/client, Bazel integration, observability
+Kotlin: Armeria+Dagger+Clikt+OTel+coroutines reference
+
+§APPROACH
+complexity-parity sprints: coherent chunks impl+test+review independent
+TDD throughout; test-first for new components
+
+§STEPS
+
+§SPRINT1: Foundations (Library Selection & Structure)
+complexity:low — baseline no deep impl
+tickets:PY-009 PY-003
+deliver: finalize libs (requirements.txt MODULE.bazel); restructure Pythonic layout (packages tests/); update Bazel targets; merge foundation PR
+
+§SPRINT2: gRPC Infrastructure
+complexity:medium — core comm layer
+tickets:PY-004 PY-002
+deliver: py_grpc_library stubs; fix proto integration (imports foo()); basic gRPC channel/server tests; merge infra PR
+
+§SPRINT3: Service Implementation
+complexity:high — biz logic+server
+tickets:PY-005 PY-007(service binary)
+deliver: BalanceService w/ telemetry logging error handling; py_binary service; CLI host/port/env flags; unit tests; merge service PR
+
+§SPRINT4: Client Implementation
+complexity:medium — user client
+tickets:PY-006 PY-007(client binary)
+deliver: async client w/ telemetry; CLI matching Kotlin; stdin input stdout output; py_binary client; merge client PR
+
+§SPRINT5: Testing & Integration
+complexity:medium-high — validation cross-component
+tickets:PY-008
+deliver: comprehensive unit tests; integration client-server; pytest-asyncio async tests; e2e parity verify; final merge
+
+§RISKS
+async patterns Python vs Kotlin coroutines — validate integration tests
+OTel setup complexity — test local OTLP collector
+Bazel Python rules edge cases — iterate BUILD files
+
+§DONE
+all sprints complete; Python interoperable w/ Kotlin+others; full test coverage; exemplar Python quality

--- a/thoughts/shared/plans/2026-04-25-python-parity-implementation-plan.md
+++ b/thoughts/shared/plans/2026-04-25-python-parity-implementation-plan.md
@@ -1,0 +1,80 @@
+---
+date: 2026-04-25
+author: Qwen Code
+ticket: PY-001
+status: draft
+---
+
+# Python Parity Implementation Plan
+
+## Goal
+
+Bring the Python implementation to full feature parity with the Kotlin reference, using Python community norms and equivalent patterns for libraries, async handling, CLI, logging, and telemetry.
+
+## Context
+
+The Python project currently has a core bracket balancing library and basic tests, but lacks gRPC service/client, proper Bazel integration, and observability features. Kotlin provides the reference implementation with Armeria server, Dagger DI, Clikt CLI, OpenTelemetry telemetry, and coroutine-based async I/O.
+
+## Approach
+
+Follow a complexity-parity sprint sequence (not time-boxed) breaking work into coherent chunks that can be implemented, tested, and reviewed independently. Use TDD principles throughout, with test-first design for new components.
+
+## Steps
+
+### Sprint 1: Foundations (Library Selection & Structure)
+**Complexity**: Low - Establishes baseline without deep implementation
+**Tickets**: PY-009, PY-003
+**Deliverables**:
+- Finalize library choices in PY-009 (add to requirements.txt, MODULE.bazel)
+- Restructure codebase to Pythonic layout (packages, tests/)
+- Update Bazel targets for new structure
+- Commit and merge foundation changes
+
+### Sprint 2: gRPC Infrastructure
+**Complexity**: Medium - Core communication layer
+**Tickets**: PY-004, PY-002
+**Deliverables**:
+- Set up py_grpc_library for generated stubs
+- Fix proto integration (enable imports, update foo())
+- Basic gRPC channel/server setup tests
+- Merge infrastructure PR
+
+### Sprint 3: Service Implementation
+**Complexity**: High - Business logic + server
+**Tickets**: PY-005, PY-007 (service binary)
+**Deliverables**:
+- Implement BalanceService with telemetry, logging, error handling
+- Add Bazel py_binary for service
+- CLI flags for host/port/environment
+- Unit tests for service logic
+- Merge service PR
+
+### Sprint 4: Client Implementation
+**Complexity**: Medium - User-facing client
+**Tickets**: PY-006, PY-007 (client binary)
+**Deliverables**:
+- Implement async client with telemetry
+- CLI interface matching Kotlin
+- Input handling (stdin), output formatting
+- Bazel py_binary for client
+- Merge client PR
+
+### Sprint 5: Testing & Integration
+**Complexity**: Medium-High - Validation and cross-component testing
+**Tickets**: PY-008
+**Deliverables**:
+- Comprehensive unit tests for all components
+- Integration tests for client-server communication
+- Async test setup with pytest-asyncio
+- End-to-end parity verification
+- Final merge
+
+## Risks
+
+- Async patterns in Python may differ from Kotlin coroutines - validate with integration tests
+- OpenTelemetry setup complexity - test with local OTLP collector
+- Bazel Python rules edge cases - iterate on BUILD files
+
+## Done
+
+All sprints completed, Python variant interoperable with Kotlin (and other languages), full test coverage, and exemplar Python code quality.

--- a/thoughts/shared/tickets/PY-003-python-src-structure-restructure.md
+++ b/thoughts/shared/tickets/PY-003-python-src-structure-restructure.md
@@ -1,0 +1,36 @@
+---
+id: PY-003
+title: Restructure Python codebase to match Kotlin src/main and src/test layout
+area: python, structure
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+Restructure the Python codebase to follow Python community conventions for project layout, while maintaining Bazel compatibility. Avoid forcing JVM-style `src/main/python` structure if it conflicts with Python norms. Organize code into appropriate packages and test directories that look natural to Python developers.
+
+## Current State
+
+- Python code is currently located in `python/brackets_py_lib/`
+- Contains `brackets_lib.py`, `brackets_lib_test.py`, and `BUILD.bazel`
+- Structure is functional but not following Python community best practices
+
+## Goals
+
+- Adopt Python-standard project structure (e.g., package directories with `__init__.py`, separate `tests/` directory)
+- Maintain Bazel build compatibility
+- Ensure code organization is intuitive for Python developers
+- Follow PEP 8 and common Python packaging patterns
+
+## Acceptance Criteria
+
+- All existing tests pass
+- Bazel `py_test` and `py_library` targets work
+- Code can be imported as `com.geekinasuit.polyglot.brackets.lib`
+- No regressions in functionality
+
+## References
+
+- Kotlin structure: `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/`
+- AGENTS.md: "mirror the Kotlin project's structure and layout where it maps naturally"

--- a/thoughts/shared/tickets/PY-004-python-grpc-generation-setup.md
+++ b/thoughts/shared/tickets/PY-004-python-grpc-generation-setup.md
@@ -1,0 +1,33 @@
+---
+id: PY-004
+title: Set up gRPC code generation for Python using py_grpc_library
+area: python, grpc, bazel
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+Add Bazel `py_grpc_library` targets to generate Python gRPC stubs from the shared protobuf definitions, mirroring the Kotlin `kt_jvm_grpc_library` setup.
+
+## Current State
+
+- `py_proto_library` exists for `//protobuf` but no gRPC stubs are generated
+- Proto import is disabled in `brackets_lib.py` due to missing gRPC dependencies
+
+## Goals
+
+- Add `py_grpc_library` target in `python/BUILD.bazel`
+- Generate gRPC service and client stubs
+- Enable proto imports in Python code
+
+## Acceptance Criteria
+
+- Bazel can build `py_grpc_library` target
+- Generated Python files appear in Bazel output
+- Proto messages can be imported and used in Python code
+
+## References
+
+- Kotlin equivalent: `kt_jvm_grpc_library` in `kotlin/BUILD.bazel`
+- Protobuf target: `//protobuf:balance_rpc`

--- a/thoughts/shared/tickets/PY-005-python-grpc-service-implementation.md
+++ b/thoughts/shared/tickets/PY-005-python-grpc-service-implementation.md
@@ -1,0 +1,36 @@
+---
+id: PY-005
+title: Implement Python gRPC service endpoint
+area: python, grpc
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+Implement the Python gRPC service endpoint that provides the bracket balancing functionality, modeling it after the Kotlin `BalanceServiceEndpoint`.
+
+## Current State
+
+- Core bracket balancing algorithm exists in `brackets_lib.py`
+- No gRPC service implementation
+- No server startup code
+
+## Goals
+
+- Create `BalanceService` class implementing the gRPC service interface
+- Handle `BalanceBrackets` RPC calls using the core algorithm
+- Add proper error handling and response formatting
+- Follow Python gRPC service patterns
+
+## Acceptance Criteria
+
+- Service can receive gRPC requests
+- Bracket balancing logic is correctly invoked
+- Responses match the protobuf schema
+- Unit tests cover service logic
+
+## References
+
+- Kotlin reference: `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/service/BalanceServiceEndpoint.kt`
+- Protobuf service: `protobuf/brackets_service.proto`

--- a/thoughts/shared/tickets/PY-006-python-grpc-client-implementation.md
+++ b/thoughts/shared/tickets/PY-006-python-grpc-client-implementation.md
@@ -1,0 +1,35 @@
+---
+id: PY-006
+title: Implement Python gRPC client
+area: python, grpc
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+Implement the Python gRPC client for connecting to bracket balancing services, modeling it after the Kotlin client implementation.
+
+## Current State
+
+- No gRPC client code exists
+- No command-line interface for client
+
+## Goals
+
+- Create client code that connects to gRPC service
+- Implement command-line interface matching Kotlin client flags
+- Accept `--host`, `--port`, input text arguments
+- Handle connection errors and display results
+
+## Acceptance Criteria
+
+- Client can connect to running service
+- CLI accepts same flags as Kotlin client
+- Output format matches Kotlin semantically
+- Error handling for connection failures
+
+## References
+
+- Kotlin reference: `kotlin/src/main/kotlin/com/geekinasuit/polyglot/brackets/client/client.kt`
+- AGENTS.md: "CLI entry points should accept the same flags (`--host`, `--port`, input argument) with the same defaults"

--- a/thoughts/shared/tickets/PY-007-python-bazel-binaries.md
+++ b/thoughts/shared/tickets/PY-007-python-bazel-binaries.md
@@ -1,0 +1,33 @@
+---
+id: PY-007
+title: Add Bazel py_binary targets for Python service and client
+area: python, bazel
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+Add Bazel `py_binary` targets for the Python gRPC service and client executables, providing runnable binaries similar to the Kotlin `java_binary` targets.
+
+## Current State
+
+- No executable targets defined
+- Only library and test targets exist
+
+## Goals
+
+- Add `py_binary` for brackets_service
+- Add `py_binary` for brackets_client
+- Include necessary runtime dependencies
+- Ensure binaries can be run with `bazel run`
+
+## Acceptance Criteria
+
+- `bazel run //python:brackets_service` starts the service
+- `bazel run //python:brackets_client` runs the client
+- Binaries include all required dependencies
+
+## References
+
+- Kotlin equivalent: `java_binary` targets in `kotlin/BUILD.bazel`

--- a/thoughts/shared/tickets/PY-008-python-service-client-tests.md
+++ b/thoughts/shared/tickets/PY-008-python-service-client-tests.md
@@ -1,0 +1,36 @@
+---
+id: PY-008
+title: Add unit and integration tests for Python gRPC service and client
+area: python, testing
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+Add comprehensive tests for the Python gRPC service and client implementations, ensuring they work correctly and match the test coverage of other language variants.
+
+## Current State
+
+- Tests exist only for the core bracket balancing library
+- No tests for gRPC service or client functionality
+
+## Goals
+
+- Add unit tests for service endpoint logic
+- Add integration tests for client-server communication
+- Test error handling and edge cases
+- Follow testing philosophy: prefer unit tests, fakes over mocks
+
+## Acceptance Criteria
+
+- Service tests cover all RPC methods
+- Client tests verify correct request/response handling
+- Tests pass with `bazel test`
+- Test coverage matches other language variants
+
+## References
+
+- Testing philosophy in AGENTS.md
+- Kotlin tests: `kotlin/src/test/kotlin/bracketskt/BracketsTest.kt`
+- Baseline: 8 unit test cases for bracket algorithm

--- a/thoughts/shared/tickets/PY-009-python-library-selection.md
+++ b/thoughts/shared/tickets/PY-009-python-library-selection.md
@@ -1,0 +1,44 @@
+---
+id: PY-009
+title: Research and select Python community-standard libraries for gRPC microservice implementation
+area: python, libraries
+status: open
+created: 2026-04-25
+---
+
+## Summary
+
+As an exemplar Python project, select libraries that represent current Python community best practices for gRPC microservices, CLI argument parsing, logging, telemetry/metrics, and other facilities. Prefer well-established, actively maintained libraries that Python developers would expect to see in a production-quality project.
+
+## Current State
+
+- Basic gRPC functionality will use `grpcio` (standard)
+- No decisions made for CLI parsing, logging, telemetry, or microservice framework choices
+- Project should demonstrate idiomatic Python development patterns
+
+## Goals
+
+Based on Kotlin patterns observed (Armeria server, Dagger DI, Clikt CLI, OpenTelemetry, KotlinLogging, coroutines):
+
+- **gRPC Framework**: `grpcio` with asyncio for async patterns (equivalent to Kotlin coroutines); `grpc-interceptor` for middleware/hooks
+- **CLI Args**: `click` for rich CLI interface (equivalent to Clikt, more Pythonic than argparse)
+- **Logging**: `logging` with `structlog` for structured logging (equivalent to KotlinLogging/slf4j structured logs)
+- **Telemetry/Metrics**: `opentelemetry-distro` + `opentelemetry-exporter-otlp-proto-grpc` for traces, counters, histograms (direct equivalent to Kotlin OpenTelemetry usage)
+- **Config**: `pyyaml` for YAML config loading (matches Kotlin's config patterns)
+- **DI/Microservice Framework**: No heavy DI framework (minimal deps); manual dependency passing or `dependency-injector` if needed. Simple gRPC server launch (equivalent to Armeria but Pythonic)
+- **Async Patterns**: asyncio throughout (equivalent to Kotlin suspend functions/coroutines)
+- **Testing**: `pytest` + `pytest-asyncio` for async tests
+- Ensure selections align with Bazel MODULE.bazel dependencies and Python community norms
+
+## Acceptance Criteria
+
+- Library choices documented and justified based on Python community adoption
+- Dependencies added to `requirements.txt` and Bazel MODULE.bazel
+- Code examples demonstrate proper usage patterns
+- Libraries are actively maintained and have good community support
+
+## References
+
+- AGENTS.md: "minimal dependencies, prefer standard library or well-established ecosystem libraries"
+- Python gRPC best practices: https://grpc.io/docs/languages/python/
+- Exemplar goal: project should look like a GOOD Python project to Python developers

--- a/thoughts/shared/tickets/TICKETS.md
+++ b/thoughts/shared/tickets/TICKETS.md
@@ -52,6 +52,13 @@ A GitHub Action (see `CI-001-github-action-ticket-close-sync.md`) will act as a 
 | `GO-001-go-grpc-client-server.md` | golang, grpc | Implement gRPC service and client; prereq: proto target fix; model after Kotlin |
 | `JAVA-001-java-grpc-client-server.md` | java, grpc | Implement gRPC service and client; model after Kotlin |
 | `PY-001-python-grpc-client-server.md` | python, grpc | Implement gRPC service and client; prereq: proto fix; model after Kotlin |
+| `PY-003-python-src-structure-restructure.md` | python, structure | Restructure Python codebase to match Kotlin src/main and src/test layout |
+| `PY-004-python-grpc-generation-setup.md` | python, grpc, bazel | Set up gRPC code generation for Python using py_grpc_library |
+| `PY-005-python-grpc-service-implementation.md` | python, grpc | Implement Python gRPC service endpoint |
+| `PY-006-python-grpc-client-implementation.md` | python, grpc | Implement Python gRPC client |
+| `PY-007-python-bazel-binaries.md` | python, bazel | Add Bazel py_binary targets for Python service and client |
+| `PY-008-python-service-client-tests.md` | python, testing | Add unit and integration tests for Python gRPC service and client |
+| `PY-009-python-library-selection.md` | python, libraries | Research and select Python community-standard libraries for gRPC microservice implementation |
 | `RUST-001-rust-grpc-client-server.md` | rust, grpc | Add `tonic`; implement gRPC service and client; model after Kotlin |
 | `TS-001-typescript-grpc-openapi-variant.md` | typescript, grpc, openapi | New language variant: gRPC svc+client (Kotlin-compatible) + OpenAPI REST; dual yarn/npm + Bazel build |
 


### PR DESCRIPTION
## Summary

Adds foundational tickets and implementation plan for bringing Python to full parity with Kotlin reference implementation.

## Changes

- **Tickets**: Created PY-003 through PY-009 covering structure, gRPC setup, service/client implementation, Bazel binaries, tests, and library selection
- **Plan**: Added 2026-04-25-python-parity-implementation-plan.md with 5-sprint breakdown using complexity-parity approach
- **TICKETS.md**: Updated index with new Python tickets

## Context

Python currently has core bracket balancing algorithm but lacks gRPC service/client, Bazel integration, and observability. This establishes the roadmap for parity using Python community norms (asyncio, click, structlog, OpenTelemetry, etc.) while mirroring Kotlin patterns.

## Next Steps

After merge, begin Sprint 1: Foundations (library selection & structure)